### PR TITLE
adds `PartialEq` for `Violation` and `IonSchemaError` and makes `violation` module public

### DIFF
--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -29,7 +29,7 @@ pub mod result;
 pub mod schema;
 pub mod system;
 pub mod types;
-mod violation;
+pub mod violation;
 
 /// Re-export of the ion-rs dependency that is part of our public API.
 pub mod external {

--- a/ion-schema/src/result.rs
+++ b/ion-schema/src/result.rs
@@ -60,8 +60,6 @@ impl PartialEq for IonSchemaError {
     }
 }
 
-impl Eq for IonSchemaError {}
-
 /// A convenience method for creating an IonSchemaResult containing an IonSchemaError::UnresolvableSchemaError
 /// with the provided description text.
 pub fn unresolvable_schema_error<T, S: AsRef<str>>(description: S) -> IonSchemaResult<T> {

--- a/ion-schema/src/result.rs
+++ b/ion-schema/src/result.rs
@@ -60,6 +60,8 @@ impl PartialEq for IonSchemaError {
     }
 }
 
+impl Eq for IonSchemaError {}
+
 /// A convenience method for creating an IonSchemaResult containing an IonSchemaError::UnresolvableSchemaError
 /// with the provided description text.
 pub fn unresolvable_schema_error<T, S: AsRef<str>>(description: S) -> IonSchemaResult<T> {

--- a/ion-schema/src/result.rs
+++ b/ion-schema/src/result.rs
@@ -40,6 +40,26 @@ pub enum IonSchemaError {
     },
 }
 
+// io::Error does not implement PartialEq, which precludes us from simply deriving an implementation.
+impl PartialEq for IonSchemaError {
+    fn eq(&self, other: &Self) -> bool {
+        use IonSchemaError::*;
+        match (self, other) {
+            // We can compare the io::Errors' ErrorKinds, offering a weak definition of equality.
+            (IoError { source: s1 }, IoError { source: s2 }) => s1.kind() == s2.kind(),
+            (
+                UnresolvableSchemaError { description: s1 },
+                UnresolvableSchemaError { description: s2 },
+            ) => s1 == s2,
+            (InvalidSchemaError { description: s1 }, InvalidSchemaError { description: s2 }) => {
+                s1 == s2
+            }
+            (IonError { source: s1 }, IonError { source: s2 }) => s1 == s2,
+            _ => false,
+        }
+    }
+}
+
 /// A convenience method for creating an IonSchemaResult containing an IonSchemaError::UnresolvableSchemaError
 /// with the provided description text.
 pub fn unresolvable_schema_error<T, S: AsRef<str>>(description: S) -> IonSchemaResult<T> {

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -3,7 +3,7 @@ use std::fmt::Formatter;
 use thiserror::Error;
 
 /// Represents [Violation] found during validation with detailed error message, error code and the constraint for which the validation failed
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, PartialEq, Error)]
 pub struct Violation {
     constraint: String,  // represents the constraint that created this violation
     code: ViolationCode, // represents an error code that indicates the type of the violation
@@ -47,7 +47,7 @@ impl fmt::Display for Violation {
 }
 
 /// Represents violation code that indicates the type of the violation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ViolationCode {
     AllTypesNotMatched,
     AnnotationMismatched,


### PR DESCRIPTION
### Issue #135, #136 

### Description of changes:
This PR works on making `violation` module public and adding `PartialEq` for `Violation` and `IonSchemaError`

### List changes
* adds `PartialEq` implementation for `IonSchemaError`
* Derives `PartialEq` for `ViolationCode` and Violation
* makes violation module public

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
