### PR TITLE
Modifies violation messages to include ISL struct for annoymous type definitions

### DIFF
--- a/ion-schema-tests-runner/src/generator.rs
+++ b/ion-schema-tests-runner/src/generator.rs
@@ -91,8 +91,8 @@ fn generate_test_cases_for_file(ctx: Context) -> TokenStream {
     let schema_id = match ctx.current_dir.strip_prefix(ctx.root_dir) {
         Ok(p) => p
             .to_str()
-            .unwrap_or_else(|| panic!("Path cannot be converted to a string: {:?}", p)),
-        Err(e) => panic!("Path is not in the root {} – {}", path_string, e),
+            .unwrap_or_else(|| panic!("Path cannot be converted to a string: {p:?}")),
+        Err(e) => panic!("Path is not in the root {path_string} – {e}"),
     };
 
     let mut test_case_tokens: Vec<TokenStream> = Vec::new();
@@ -118,16 +118,16 @@ fn generate_test_cases_for_file(ctx: Context) -> TokenStream {
 
     // get the schema content from given schema file path
     let ion_content = fs::read(ctx.current_dir.as_path())
-        .unwrap_or_else(|e| panic!("Unable to read {path_string} – {}", e));
+        .unwrap_or_else(|e| panic!("Unable to read {path_string} – {e}"));
     let schema_content = element_reader()
         .read_all(&ion_content)
-        .unwrap_or_else(|e| panic!("Error in {path_string} – {:?}", e));
+        .unwrap_or_else(|e| panic!("Error in {path_string} – {e:?}"));
 
     for element in schema_content {
         if element.has_annotation("$test") {
             let test_cases: TestCaseVec = element
                 .try_into()
-                .unwrap_or_else(|e| panic!("Error in {path_string} - {}", e));
+                .unwrap_or_else(|e| panic!("Error in {path_string} - {e}"));
 
             for test_case in test_cases.iter() {
                 let test_case = test_case.clone();

--- a/ion-schema-tests-runner/src/model.rs
+++ b/ion-schema-tests-runner/src/model.rs
@@ -102,9 +102,7 @@ impl TryFrom<Element> for TestCaseVec {
                     })
                 }
             } else {
-                return Err(format!(
-                    "Malformed test case - unknown test type: {value}"
-                ));
+                return Err(format!("Malformed test case - unknown test type: {value}"));
             }
         } else if test_case_struct.get("type").is_some()
             && (test_case_struct.get("should_accept_as_valid").is_some()

--- a/ion-schema-tests-runner/src/model.rs
+++ b/ion-schema-tests-runner/src/model.rs
@@ -41,7 +41,7 @@ impl TryFrom<Element> for TestCaseVec {
     type Error = String;
     fn try_from(value: Element) -> Result<Self, Self::Error> {
         let test_case_struct = match value.as_struct() {
-            None => Err(format!("Malformed test case: {}", value)),
+            None => Err(format!("Malformed test case: {value}")),
             Some(struct_) => Ok(struct_),
         }?;
 
@@ -103,8 +103,7 @@ impl TryFrom<Element> for TestCaseVec {
                 }
             } else {
                 return Err(format!(
-                    "Malformed test case - unknown test type: {}",
-                    value
+                    "Malformed test case - unknown test type: {value}"
                 ));
             }
         } else if test_case_struct.get("type").is_some()

--- a/ion-schema/src/authority.rs
+++ b/ion-schema/src/authority.rs
@@ -133,8 +133,7 @@ impl DocumentAuthority for MapDocumentAuthority {
         // if ion content exists for the given id  in the map then return ion content as Elements
         let ion_content = self.ion_content_by_id.get(id).ok_or_else(|| {
             unresolvable_schema_error_raw(format!(
-                "MapDocumentAuthority does not contain schema with id: {}",
-                id
+                "MapDocumentAuthority does not contain schema with id: {id}"
             ))
         })?;
         let iterator = element_reader().iterate_over(ion_content.as_bytes())?;

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -424,7 +424,7 @@ impl ConstraintValidator for AllOfConstraint {
             return Err(Violation::with_violations(
                 "all_of",
                 ViolationCode::AllTypesNotMatched,
-                &format!(
+                format!(
                     "value matches {} types, expected {}",
                     valid_types.len(),
                     self.type_ids.len()
@@ -535,7 +535,7 @@ impl ConstraintValidator for OneOfConstraint {
             _ => Err(Violation::with_violations(
                 "one_of",
                 ViolationCode::MoreThanOneTypeMatched,
-                &format!("value matches {} types, expected 1", total_valid_types),
+                format!("value matches {total_valid_types} types, expected 1"),
                 violations,
             )),
         }
@@ -690,8 +690,7 @@ impl OrderedElementsConstraint {
                     "ordered_elements",
                     ViolationCode::TypeMismatched,
                     &format!(
-                        "Expected {} of type {}: found {}",
-                        occurs_range, type_def, count
+                        "Expected {occurs_range} of type {type_def}: found {count}"
                     ),
                 ));
             }
@@ -721,8 +720,7 @@ impl OrderedElementsConstraint {
                 "ordered_elements",
                 ViolationCode::TypeMismatched,
                 &format!(
-                    "Expected {} of type {}: found {}",
-                    occurs_range, type_def, count
+                    "Expected {occurs_range} of type {type_def}: found {count}"
                 ),
             ));
         }
@@ -743,10 +741,10 @@ impl ConstraintValidator for OrderedElementsConstraint {
                     return Err(Violation::with_violations(
                         "ordered_elements",
                         ViolationCode::TypeMismatched,
-                        &format!(
+                        format!(
                             "expected list/sexp ion found {}",
                             if element.is_null() {
-                                format!("{}", element)
+                                format!("{element}")
                             } else {
                                 format!("{}", element.ion_type())
                             }
@@ -781,7 +779,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
                 "ordered_elements",
                 ViolationCode::TypeMismatched,
                 // unwrap as we already verified with peek that there is a value
-                &format!("Unexpected type found {}", values_iter.next().unwrap()),
+                format!("Unexpected type found {}", values_iter.next().unwrap()),
                 violations,
             ))
         } else {
@@ -847,8 +845,7 @@ impl ConstraintValidator for FieldsConstraint {
                         "fields",
                         ViolationCode::InvalidOpenContent,
                         &format!(
-                            "Found open content in the struct: {}: {}",
-                            field_name, value
+                            "Found open content in the struct: {field_name}: {value}"
                         ),
                     ));
                 }
@@ -928,7 +925,7 @@ impl ConstraintValidator for ContainsConstraint {
                             &format!(
                                 "expected list/sexp found {}",
                                 if element.is_null() {
-                                    format!("{}", element)
+                                    format!("{element}")
                                 } else {
                                     format!("{}", element.ion_type())
                                 }
@@ -957,7 +954,7 @@ impl ConstraintValidator for ContainsConstraint {
             return Err(Violation::new(
                 "contains",
                 ViolationCode::MissingValue,
-                &format!("{} has missing value(s): {:?}", value, missing_values),
+                &format!("{value} has missing value(s): {missing_values:?}"),
             ));
         }
 
@@ -992,7 +989,7 @@ impl ConstraintValidator for ContainerLengthConstraint {
                     return Err(Violation::new(
                         "container_length",
                         ViolationCode::TypeMismatched,
-                        &format!("expected a container found {}", element),
+                        &format!("expected a container found {element}"),
                     ));
                 }
 
@@ -1025,7 +1022,7 @@ impl ConstraintValidator for ContainerLengthConstraint {
             return Err(Violation::new(
                 "container_length",
                 ViolationCode::InvalidLength,
-                &format!("expected container length {} found {}", length_range, size),
+                &format!("expected container length {length_range} found {size}"),
             ));
         }
 
@@ -1067,7 +1064,7 @@ impl ConstraintValidator for ByteLengthConstraint {
             return Err(Violation::new(
                 "byte_length",
                 ViolationCode::InvalidLength,
-                &format!("expected byte length {} found {}", length_range, size),
+                &format!("expected byte length {length_range} found {size}"),
             ));
         }
 
@@ -1110,7 +1107,7 @@ impl ConstraintValidator for CodepointLengthConstraint {
             return Err(Violation::new(
                 "codepoint_length",
                 ViolationCode::InvalidLength,
-                &format!("expected codepoint length {} found {}", length_range, size),
+                &format!("expected codepoint length {length_range} found {size}"),
             ));
         }
 
@@ -1157,7 +1154,7 @@ impl ConstraintValidator for ElementConstraint {
                     return Err(Violation::new(
                         "element",
                         ViolationCode::TypeMismatched,
-                        &format!("expected a container but found {}", element),
+                        &format!("expected a container but found {element}"),
                     ));
                 }
 
@@ -1299,7 +1296,7 @@ impl AnnotationsConstraint {
                 "annotations",
                 ViolationCode::AnnotationMismatched,
                 // unwrap as we already verified with peek that there is a value
-                &format!(
+                format!(
                     "Unexpected annotations found {}",
                     value_annotations.next().unwrap()
                 ),
@@ -1338,7 +1335,7 @@ impl AnnotationsConstraint {
             return Err(Violation::with_violations(
                 "annotations",
                 ViolationCode::MissingAnnotation,
-                &format!("missing annotation(s): {:?}", missing_annotations),
+                format!("missing annotation(s): {missing_annotations:?}"),
                 violations,
             ));
         }
@@ -1425,8 +1422,7 @@ impl ConstraintValidator for PrecisionConstraint {
                 "precision",
                 ViolationCode::InvalidLength,
                 &format!(
-                    "expected precision {} found {}",
-                    precision_range, value_precision
+                    "expected precision {precision_range} found {value_precision}"
                 ),
             ));
         }
@@ -1469,7 +1465,7 @@ impl ConstraintValidator for ScaleConstraint {
             return Err(Violation::new(
                 "scale",
                 ViolationCode::InvalidLength,
-                &format!("expected scale {} found {}", scale_range, value_scale),
+                &format!("expected scale {scale_range} found {value_scale}"),
             ));
         }
 
@@ -1554,10 +1550,10 @@ impl Display for ValidValuesConstraint {
         write!(f, "[ ")?;
         let mut itr = self.valid_values.iter();
         if let Some(item) = itr.next() {
-            write!(f, "{}", item)?;
+            write!(f, "{item}")?;
         }
         for item in itr {
-            write!(f, ", {}", item)?;
+            write!(f, ", {item}")?;
         }
         write!(f, " ]")
     }
@@ -1647,7 +1643,7 @@ impl RegexConstraint {
                     sb.push(ch);
                     if let Some(ch) = si.next() {
                         if ch == '?' {
-                            return invalid_schema_error(format!("invalid character {}", ch));
+                            return invalid_schema_error(format!("invalid character {ch}"));
                         }
                         sb.push(ch)
                     }
@@ -1666,8 +1662,7 @@ impl RegexConstraint {
                             'S' => sb.push_str("[^ \\f\\n\\r\\t]"),
                             _ => {
                                 return invalid_schema_error(format!(
-                                    "invalid escape character {}",
-                                    ch,
+                                    "invalid escape character {ch}",
                                 ))
                             }
                         }
@@ -1702,8 +1697,7 @@ impl RegexConstraint {
                             // as user is specifying a new char class
                             _ => {
                                 return invalid_schema_error(format!(
-                                    "invalid sequence '\\{}' in character class",
-                                    ch2
+                                    "invalid sequence '\\{ch2}' in character class"
                                 ))
                             }
                         }
@@ -1743,7 +1737,7 @@ impl RegexConstraint {
                                 complete = true;
                                 break;
                             }
-                            _ => return invalid_schema_error(format!("invalid character {}", ch)),
+                            _ => return invalid_schema_error(format!("invalid character {ch}")),
                         }
                     }
 
@@ -1756,9 +1750,9 @@ impl RegexConstraint {
             if sb.len() > initial_length {
                 if let Some(ch) = si.peek().cloned() {
                     match ch {
-                        '?' => return invalid_schema_error(format!("invalid character {}", ch)),
+                        '?' => return invalid_schema_error(format!("invalid character {ch}")),
 
-                        '+' => return invalid_schema_error(format!("invalid character {}", ch)),
+                        '+' => return invalid_schema_error(format!("invalid character {ch}")),
                         _ => {}
                     }
                 }
@@ -1859,7 +1853,7 @@ impl ConstraintValidator for Utf8ByteLengthConstraint {
             return Err(Violation::new(
                 "utf8_byte_length",
                 ViolationCode::InvalidLength,
-                &format!("expected utf8 byte length {} found {}", length_range, size),
+                &format!("expected utf8 byte length {length_range} found {size}"),
             ));
         }
 
@@ -1898,7 +1892,7 @@ impl ConstraintValidator for TimestampOffsetConstraint {
         // return a Violation if the value didn't follow timestamp precision constraint
         if !valid_offsets.contains(&timestamp_value.offset().into()) {
             let formatted_valid_offsets: Vec<String> =
-                valid_offsets.iter().map(|t| format!("{}", t)).collect();
+                valid_offsets.iter().map(|t| format!("{t}")).collect();
 
             return Err(Violation::new(
                 "timestamp_offset",

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -690,7 +690,7 @@ impl OrderedElementsConstraint {
                     "ordered_elements",
                     ViolationCode::TypeMismatched,
                     &format!(
-                        "Expected {:?} of type {:?}: found {}",
+                        "Expected {} of type {}: found {}",
                         occurs_range, type_def, count
                     ),
                 ));
@@ -721,7 +721,7 @@ impl OrderedElementsConstraint {
                 "ordered_elements",
                 ViolationCode::TypeMismatched,
                 &format!(
-                    "Expected {:?} of type {:?}: found {}",
+                    "Expected {} of type {:?}: found {}",
                     occurs_range, type_def, count
                 ),
             ));
@@ -746,7 +746,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
                         &format!(
                             "expected list/sexp ion found {}",
                             if element.is_null() {
-                                format!("{:?}", element)
+                                format!("{}", element)
                             } else {
                                 format!("{}", element.ion_type())
                             }
@@ -847,7 +847,7 @@ impl ConstraintValidator for FieldsConstraint {
                         "fields",
                         ViolationCode::InvalidOpenContent,
                         &format!(
-                            "Found open content in the struct: {:?}: {:?}",
+                            "Found open content in the struct: {}: {}",
                             field_name, value
                         ),
                     ));
@@ -869,7 +869,7 @@ impl ConstraintValidator for FieldsConstraint {
                     "fields",
                     ViolationCode::TypeMismatched,
                     &format!(
-                        "Expected {:?} of field {:?}: found {}",
+                        "Expected {} of field {}: found {}",
                         occurs_range,
                         field_name,
                         values.len()
@@ -928,7 +928,7 @@ impl ConstraintValidator for ContainsConstraint {
                             &format!(
                                 "expected list/sexp found {}",
                                 if element.is_null() {
-                                    format!("{:?}", element)
+                                    format!("{}", element)
                                 } else {
                                     format!("{}", element.ion_type())
                                 }
@@ -957,7 +957,7 @@ impl ConstraintValidator for ContainsConstraint {
             return Err(Violation::new(
                 "contains",
                 ViolationCode::MissingValue,
-                &format!("{:?} has missing value(s): {:?}", value, missing_values),
+                &format!("{} has missing value(s): {:?}", value, missing_values),
             ));
         }
 
@@ -992,7 +992,7 @@ impl ConstraintValidator for ContainerLengthConstraint {
                     return Err(Violation::new(
                         "container_length",
                         ViolationCode::TypeMismatched,
-                        &format!("expected a container found {:?}", element),
+                        &format!("expected a container found {}", element),
                     ));
                 }
 
@@ -1025,10 +1025,7 @@ impl ConstraintValidator for ContainerLengthConstraint {
             return Err(Violation::new(
                 "container_length",
                 ViolationCode::InvalidLength,
-                &format!(
-                    "expected container length {:?} found {}",
-                    length_range, size
-                ),
+                &format!("expected container length {} found {}", length_range, size),
             ));
         }
 
@@ -1070,7 +1067,7 @@ impl ConstraintValidator for ByteLengthConstraint {
             return Err(Violation::new(
                 "byte_length",
                 ViolationCode::InvalidLength,
-                &format!("expected byte length {:?} found {}", length_range, size),
+                &format!("expected byte length {} found {}", length_range, size),
             ));
         }
 
@@ -1113,10 +1110,7 @@ impl ConstraintValidator for CodepointLengthConstraint {
             return Err(Violation::new(
                 "codepoint_length",
                 ViolationCode::InvalidLength,
-                &format!(
-                    "expected codepoint length {:?} found {}",
-                    length_range, size
-                ),
+                &format!("expected codepoint length {} found {}", length_range, size),
             ));
         }
 
@@ -1163,7 +1157,7 @@ impl ConstraintValidator for ElementConstraint {
                     return Err(Violation::new(
                         "element",
                         ViolationCode::TypeMismatched,
-                        &format!("expected a container but found {:?}", element),
+                        &format!("expected a container but found {}", element),
                     ));
                 }
 
@@ -1431,7 +1425,7 @@ impl ConstraintValidator for PrecisionConstraint {
                 "precision",
                 ViolationCode::InvalidLength,
                 &format!(
-                    "expected precision {:?} found {}",
+                    "expected precision {} found {}",
                     precision_range, value_precision
                 ),
             ));
@@ -1475,7 +1469,7 @@ impl ConstraintValidator for ScaleConstraint {
             return Err(Violation::new(
                 "scale",
                 ViolationCode::InvalidLength,
-                &format!("expected scale {:?} found {}", scale_range, value_scale),
+                &format!("expected scale {} found {}", scale_range, value_scale),
             ));
         }
 
@@ -1519,7 +1513,7 @@ impl ConstraintValidator for TimestampPrecisionConstraint {
                 "precision",
                 ViolationCode::InvalidLength,
                 &format!(
-                    "expected precision {:?} found {:?}",
+                    "expected precision {} found {:?}",
                     precision_range,
                     timestamp_value.precision()
                 ),
@@ -1865,10 +1859,7 @@ impl ConstraintValidator for Utf8ByteLengthConstraint {
             return Err(Violation::new(
                 "utf8_byte_length",
                 ViolationCode::InvalidLength,
-                &format!(
-                    "expected utf8 byte length {:?} found {}",
-                    length_range, size
-                ),
+                &format!("expected utf8 byte length {} found {}", length_range, size),
             ));
         }
 

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -721,7 +721,7 @@ impl OrderedElementsConstraint {
                 "ordered_elements",
                 ViolationCode::TypeMismatched,
                 &format!(
-                    "Expected {} of type {:?}: found {}",
+                    "Expected {} of type {}: found {}",
                     occurs_range, type_def, count
                 ),
             ));
@@ -781,7 +781,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
                 "ordered_elements",
                 ViolationCode::TypeMismatched,
                 // unwrap as we already verified with peek that there is a value
-                &format!("Unexpected type found {:?}", values_iter.next().unwrap()),
+                &format!("Unexpected type found {}", values_iter.next().unwrap()),
                 violations,
             ))
         } else {
@@ -1300,7 +1300,7 @@ impl AnnotationsConstraint {
                 ViolationCode::AnnotationMismatched,
                 // unwrap as we already verified with peek that there is a value
                 &format!(
-                    "Unexpected annotations found {:?}",
+                    "Unexpected annotations found {}",
                     value_annotations.next().unwrap()
                 ),
                 violations,

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -689,9 +689,7 @@ impl OrderedElementsConstraint {
                 return Err(Violation::new(
                     "ordered_elements",
                     ViolationCode::TypeMismatched,
-                    &format!(
-                        "Expected {occurs_range} of type {type_def}: found {count}"
-                    ),
+                    &format!("Expected {occurs_range} of type {type_def}: found {count}"),
                 ));
             }
         }
@@ -719,9 +717,7 @@ impl OrderedElementsConstraint {
             return Err(Violation::new(
                 "ordered_elements",
                 ViolationCode::TypeMismatched,
-                &format!(
-                    "Expected {occurs_range} of type {type_def}: found {count}"
-                ),
+                &format!("Expected {occurs_range} of type {type_def}: found {count}"),
             ));
         }
 
@@ -844,9 +840,7 @@ impl ConstraintValidator for FieldsConstraint {
                     violations.push(Violation::new(
                         "fields",
                         ViolationCode::InvalidOpenContent,
-                        &format!(
-                            "Found open content in the struct: {field_name}: {value}"
-                        ),
+                        &format!("Found open content in the struct: {field_name}: {value}"),
                     ));
                 }
             }
@@ -1421,9 +1415,7 @@ impl ConstraintValidator for PrecisionConstraint {
             return Err(Violation::new(
                 "precision",
                 ViolationCode::InvalidLength,
-                &format!(
-                    "expected precision {precision_range} found {value_precision}"
-                ),
+                &format!("expected precision {precision_range} found {value_precision}"),
             ));
         }
 

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -433,8 +433,8 @@ impl IslConstraint {
                     }
                     _ => {
                         return invalid_schema_error(format!(
-                            "`timestamp_offset` requires a list of offset strings, but found: {value}"
-                        ))
+                        "`timestamp_offset` requires a list of offset strings, but found: {value}"
+                    ))
                     }
                 };
                 Ok(IslConstraint::TimestampOffset(

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -267,8 +267,7 @@ impl IslConstraint {
                 if let Some(closed) = value.as_sym().unwrap().text() {
                     if closed != "closed" {
                         return Err(invalid_schema_error_raw(format!(
-                            "content constraint was a {} instead of a symbol `closed`",
-                            closed
+                            "content constraint was a {closed} instead of a symbol `closed`"
                         )));
                     }
                 }
@@ -329,8 +328,7 @@ impl IslConstraint {
                             "required" => Range::required(),
                             _ => {
                                 return invalid_schema_error(format!(
-                                    "only optional and required symbols are supported with occurs constraint, found {}",
-                                    sym
+                                    "only optional and required symbols are supported with occurs constraint, found {sym}"
                                 ))
                             }
                         }
@@ -414,15 +412,13 @@ impl IslConstraint {
 
                                 if e.ion_type() != IonType::String {
                                     return invalid_schema_error(format!(
-                                    "`timestamp_offset` values must be non-null strings, found {}",
-                                    e
+                                    "`timestamp_offset` values must be non-null strings, found {e}"
                                 ));
                                 }
 
                                 if e.annotations().next().is_some() {
                                     return invalid_schema_error(format!(
-                                        "`timestamp_offset` values may not be annotated, found {}",
-                                        e
+                                        "`timestamp_offset` values may not be annotated, found {e}"
                                     ));
                                 }
 
@@ -437,8 +433,7 @@ impl IslConstraint {
                     }
                     _ => {
                         return invalid_schema_error(format!(
-                            "`timestamp_offset` requires a list of offset strings, but found: {}",
-                            value
+                            "`timestamp_offset` requires a list of offset strings, but found: {value}"
                         ))
                     }
                 };
@@ -470,8 +465,7 @@ impl IslConstraint {
         //TODO: create a method/macro for this ion type check which can be reused
         if value.is_null() {
             return Err(invalid_schema_error_raw(format!(
-                "{} constraint was a null instead of a list",
-                constraint_name
+                "{constraint_name} constraint was a null instead of a list"
             )));
         }
         if value.ion_type() != IonType::List {

--- a/ion-schema/src/isl/isl_range.rs
+++ b/ion-schema/src/isl/isl_range.rs
@@ -235,15 +235,13 @@ impl Range {
                 if v >= min_value {
                     match v.try_into() {
                         Err(_) => invalid_schema_error(format!(
-                            "Expected non negative integer greater than {} for range boundary values, found {}",
-                            min_value, v
+                            "Expected non negative integer greater than {min_value} for range boundary values, found {v}"
                         )),
                         Ok(non_negative_int_value) => Ok(non_negative_int_value),
                     }
                 } else {
                     invalid_schema_error(format!(
-                        "Expected non negative integer greater than {} for range boundary values, found {}",
-                        min_value, v
+                        "Expected non negative integer greater than {min_value} for range boundary values, found {v}"
                     ))
                 }
             }
@@ -255,15 +253,13 @@ impl Range {
                     if v >= &BigInt::from(min_value) {
                         match v.try_into() {
                             Err(_) => invalid_schema_error(format!(
-                                "Expected non negative integer greater than {} for range boundary values, found {}",
-                                min_value,v
+                                "Expected non negative integer greater than {min_value} for range boundary values, found {v}"
                             )),
                             Ok(non_negative_int_value) => Ok(non_negative_int_value),
                         }
                     } else {
                         invalid_schema_error(format!(
-                            "Expected non negative integer greater than {} for range boundary values, found {}",
-                            min_value, v
+                            "Expected non negative integer greater than {min_value} for range boundary values, found {v}"
                         ))
                     }
                 }
@@ -363,15 +359,15 @@ impl From<NumberRange> for Range {
 impl Display for Range {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match &self {
-            Range::Integer(integer) => write!(f, "{}", integer),
+            Range::Integer(integer) => write!(f, "{integer}"),
             Range::NonNegativeInteger(non_negative_integer) => {
-                write!(f, "{}", non_negative_integer)
+                write!(f, "{non_negative_integer}")
             }
-            Range::TimestampPrecision(timestamp_precision) => write!(f, "{}", timestamp_precision),
-            Range::Timestamp(timestamp) => write!(f, "{}", timestamp),
-            Range::Decimal(decimal) => write!(f, "{}", decimal),
-            Range::Float(float) => write!(f, "{}", float),
-            Range::Number(number) => write!(f, "{}", number),
+            Range::TimestampPrecision(timestamp_precision) => write!(f, "{timestamp_precision}"),
+            Range::Timestamp(timestamp) => write!(f, "{timestamp}"),
+            Range::Decimal(decimal) => write!(f, "{decimal}"),
+            Range::Float(float) => write!(f, "{float}"),
+            Range::Number(number) => write!(f, "{number}"),
         }
     }
 }
@@ -770,8 +766,7 @@ impl TypedRangeBoundaryValue {
                     range_boundary_type,
                 ))),
                 _ => invalid_schema_error(format!(
-                    "{:?} ranges can not be constructed for decimal boundary values",
-                    range_type
+                    "{range_type:?} ranges can not be constructed for decimal boundary values"
                 )),
             },
             IonType::Float => match range_type {
@@ -786,8 +781,7 @@ impl TypedRangeBoundaryValue {
                     range_boundary_type,
                 ))),
                 _ => invalid_schema_error(format!(
-                    "{:?} ranges can not be constructed for float boundary values",
-                    range_type
+                    "{range_type:?} ranges can not be constructed for float boundary values"
                 )),
             },
             IonType::Timestamp => match range_type {
@@ -798,8 +792,7 @@ impl TypedRangeBoundaryValue {
                     )),
                 ),
                 _ => invalid_schema_error(format!(
-                    "{:?} ranges can not be constructed for timestamp boundary values",
-                    range_type
+                    "{range_type:?} ranges can not be constructed for timestamp boundary values"
                 )),
             },
             _ => invalid_schema_error(format!(
@@ -870,7 +863,7 @@ impl<T: Display> Display for RangeBoundaryValue<T> {
                 Max => "max".to_string(),
                 Min => "min".to_string(),
                 Value(value, range_boundary_type) => {
-                    format!("{}{}", range_boundary_type, value)
+                    format!("{range_boundary_type}{value}")
                 }
             }
         )
@@ -939,7 +932,7 @@ impl TryFrom<f64> for Number {
                 PRECISION = f64::MANTISSA_DIGITS as usize
             ))
             .map_err(|err| {
-                invalid_schema_error_raw(format!("Cannot convert f64 to BigDecimal for {}", value))
+                invalid_schema_error_raw(format!("Cannot convert f64 to BigDecimal for {value}"))
             })?,
         })
     }

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -14,12 +14,16 @@ pub enum IslType {
 impl IslType {
     /// Creates a [IslType::Named] using the [IslConstraint] defined within it
     pub fn named<A: Into<String>, B: Into<Vec<IslConstraint>>>(name: A, constraints: B) -> IslType {
-        IslType::Named(IslTypeImpl::new(Some(name.into()), constraints.into()))
+        IslType::Named(IslTypeImpl::new(
+            Some(name.into()),
+            constraints.into(),
+            None,
+        ))
     }
 
     /// Creates a [IslType::Anonymous] using the [IslConstraint] defined within it
     pub fn anonymous<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslType {
-        IslType::Anonymous(IslTypeImpl::new(None, constraints.into()))
+        IslType::Anonymous(IslTypeImpl::new(None, constraints.into(), None))
     }
 
     /// Provides a name if the ISL type is named type definition
@@ -55,11 +59,22 @@ impl IslType {
 pub struct IslTypeImpl {
     name: Option<String>,
     constraints: Vec<IslConstraint>,
+    // Represents the ISL type struct in string format for anonymous type definition
+    // For named type definition, this will be `None`
+    pub(crate) isl_type_struct: Option<String>,
 }
 
 impl IslTypeImpl {
-    pub fn new(name: Option<String>, constraints: Vec<IslConstraint>) -> Self {
-        Self { name, constraints }
+    pub fn new(
+        name: Option<String>,
+        constraints: Vec<IslConstraint>,
+        isl_type_struct: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            constraints,
+            isl_type_struct,
+        }
     }
 
     pub fn name(&self) -> &Option<String> {
@@ -146,7 +161,11 @@ impl IslTypeImpl {
             )?;
             constraints.push(constraint);
         }
-        Ok(IslTypeImpl::new(type_name, constraints))
+        Ok(IslTypeImpl::new(
+            type_name,
+            constraints,
+            Some(format!("{}", ion)),
+        ))
     }
 }
 

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -60,15 +60,15 @@ pub struct IslTypeImpl {
     name: Option<String>,
     constraints: Vec<IslConstraint>,
     // Represents the ISL type struct in string format for anonymous type definition
-    // For named type definition, this will be `None`
-    pub(crate) isl_type_struct: Option<String>,
+    // For named type definition & programmatically created type definition, this will be `None`
+    pub(crate) isl_type_struct: Option<Element>,
 }
 
 impl IslTypeImpl {
     pub fn new(
         name: Option<String>,
         constraints: Vec<IslConstraint>,
-        isl_type_struct: Option<String>,
+        isl_type_struct: Option<Element>,
     ) -> Self {
         Self {
             name,
@@ -164,7 +164,7 @@ impl IslTypeImpl {
         Ok(IslTypeImpl::new(
             type_name,
             constraints,
-            Some(format!("{}", ion)),
+            Some(ion.to_owned()),
         ))
     }
 }

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -138,7 +138,7 @@ impl IslTypeImpl {
         // set the isl type name for any error that is returned while parsing its constraints
         let isl_type_name = match type_name.to_owned() {
             Some(name) => name,
-            None => format!("{:?}", ion_struct),
+            None => format!("{ion_struct:?}"),
         };
 
         // parses all the constraints inside a Type

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -32,7 +32,7 @@ impl IslTypeRef {
 
     /// Creates a [IslTypeRef::Anonymous] using the [IonType] referenced inside it
     pub fn anonymous<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslTypeRef {
-        IslTypeRef::Anonymous(IslTypeImpl::new(None, constraints.into()))
+        IslTypeRef::Anonymous(IslTypeImpl::new(None, constraints.into(), None))
     }
 
     /// Provides a string representing a definition of a nullable built in type reference

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -98,8 +98,7 @@ impl TryFrom<&str> for TimestampPrecision {
             "nanosecond" => TimestampPrecision::Nanosecond,
             _ => {
                 return invalid_schema_error(format!(
-                    "Invalid timestamp precision specified {}",
-                    value
+                    "Invalid timestamp precision specified {value}"
                 ))
             }
         })
@@ -189,8 +188,8 @@ impl TryFrom<&Element> for ValidValue {
 impl Display for ValidValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            ValidValue::Range(range) => write!(f, "{}", range),
-            ValidValue::Element(element) => write!(f, "{}", element),
+            ValidValue::Range(range) => write!(f, "{range}"),
+            ValidValue::Element(element) => write!(f, "{element}"),
         }
     }
 }
@@ -236,7 +235,7 @@ impl TryFrom<&str> for TimestampOffset {
                 {
                     Ok(TimestampOffset::Known(sign * (hours * 60 + minutes)))
                 }
-                _ => invalid_schema_error(format!("invalid timestamp offset {}", string_value)),
+                _ => invalid_schema_error(format!("invalid timestamp offset {string_value}")),
             }
         }
     }
@@ -261,7 +260,7 @@ impl Display for TimestampOffset {
                 let sign = if offset < &0 { "-" } else { "+" };
                 let hours = abs(*offset) / 60;
                 let minutes = abs(*offset) - hours * 60;
-                write!(f, "{}{:02}:{:02}", sign, hours, minutes)
+                write!(f, "{sign}{hours:02}:{minutes:02}")
             }
         }
     }

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -98,7 +98,7 @@ impl IonSchemaElement {
                 Err(Violation::new(
                     constraint_name,
                     ViolationCode::TypeMismatched,
-                    &format!("expected {:?} but found document", types),
+                    &format!("expected {types:?} but found document"),
                 ))
             }
         }
@@ -109,12 +109,12 @@ impl Display for IonSchemaElement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             IonSchemaElement::SingleElement(element) => {
-                write!(f, "{}", element)
+                write!(f, "{element}")
             }
             IonSchemaElement::Document(document) => {
                 write!(f, "/* Ion document */ ")?;
                 for value in document {
-                    write!(f, "{} ", value)?;
+                    write!(f, "{value} ")?;
                 }
                 write!(f, "/* end */")
             }

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -643,8 +643,8 @@ impl TypeStore {
     ) -> TypeId {
         let builtin_type_name = match builtin_type_definition {
             BuiltInTypeDefinition::Atomic(ion_type, is_nullable) => match is_nullable {
-                Nullability::Nullable => format!("${}", ion_type),
-                Nullability::NotNullable => format!("{}", ion_type),
+                Nullability::Nullable => format!("${ion_type}"),
+                Nullability::NotNullable => format!("{ion_type}"),
             },
             BuiltInTypeDefinition::Derived(other_type) => other_type.name().to_owned().unwrap(),
         };
@@ -773,8 +773,7 @@ impl Resolver {
                 // This implementation only supports Ion Schema 1.0
                 if value.as_str() != Some(r"$ion_schema_1_0") {
                     return invalid_schema_error(format!(
-                        "Unsupported Ion Schema version: {}",
-                        value
+                        "Unsupported Ion Schema version: {value}"
                     ));
                 }
             }

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -157,7 +157,7 @@ impl TypeValidator for BuiltInTypeDefinition {
                             return Err(Violation::new(
                                 "type_constraint",
                                 ViolationCode::InvalidNull,
-                                &format!("expected type {:?} doesn't allow null", ion_type),
+                                &format!("expected type {ion_type:?} doesn't allow null"),
                             ));
                         }
                         if element.ion_type() != *ion_type {
@@ -177,7 +177,7 @@ impl TypeValidator for BuiltInTypeDefinition {
                     IonSchemaElement::Document(document) => Err(Violation::new(
                         "type_constraint",
                         ViolationCode::TypeMismatched,
-                        &format!("expected type {:?}, found document", ion_type),
+                        &format!("expected type {ion_type:?}, found document"),
                     )),
                 }
             }
@@ -207,8 +207,8 @@ impl TypeValidator for BuiltInTypeDefinition {
 impl Display for BuiltInTypeDefinition {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
-            BuiltInTypeDefinition::Atomic(ion_type, _) => write!(f, "{}", ion_type),
-            BuiltInTypeDefinition::Derived(type_def) => write!(f, "{}", type_def),
+            BuiltInTypeDefinition::Atomic(ion_type, _) => write!(f, "{ion_type}"),
+            BuiltInTypeDefinition::Derived(type_def) => write!(f, "{type_def}"),
         }
     }
 }
@@ -273,13 +273,13 @@ impl Display for TypeDefinition {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
             TypeDefinition::Named(named_type_def) => {
-                write!(f, "{}", named_type_def)
+                write!(f, "{named_type_def}")
             }
             TypeDefinition::Anonymous(anonymous_type_def) => {
-                write!(f, "{}", anonymous_type_def)
+                write!(f, "{anonymous_type_def}")
             }
             TypeDefinition::BuiltIn(builtin_type_def) => {
-                write!(f, "{}", builtin_type_def)
+                write!(f, "{builtin_type_def}")
             }
         }
     }
@@ -506,7 +506,7 @@ impl Display for TypeDefinitionImpl {
             Some(type_name) => type_name.to_owned(),
         };
 
-        write!(f, "{}", type_def_name)
+        write!(f, "{type_def_name}")
     }
 }
 

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -9,6 +9,7 @@ use crate::IonSchemaElement;
 use ion_rs::value::owned::{text_token, Element};
 use ion_rs::value::{Builder, IonElement};
 use ion_rs::IonType;
+use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 
 /// Provides validation for [`TypeDefinition`]
@@ -134,6 +135,7 @@ impl BuiltInTypeDefinition {
         let builtin_type_def = BuiltInTypeDefinition::Derived(TypeDefinitionImpl::new(
             type_name.to_owned(),
             constraints,
+            None,
         ));
         Ok(builtin_type_def)
     }
@@ -202,6 +204,15 @@ impl TypeValidator for BuiltInTypeDefinition {
     }
 }
 
+impl Display for BuiltInTypeDefinition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            BuiltInTypeDefinition::Atomic(ion_type, _) => write!(f, "{}", ion_type),
+            BuiltInTypeDefinition::Derived(type_def) => write!(f, "{}", type_def),
+        }
+    }
+}
+
 /// Represents a [`TypeDefinition`] which stores a resolved ISL type using [`TypeStore`]
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeDefinition {
@@ -219,12 +230,13 @@ impl TypeDefinition {
         TypeDefinition::Named(TypeDefinitionImpl::new(
             Some(name.into()),
             constraints.into(),
+            None,
         ))
     }
 
     /// Creates an anonymous [`TypeDefinition`] using the [`IslConstraint`] defined within it
     pub fn anonymous<A: Into<Vec<Constraint>>>(constraints: A) -> TypeDefinition {
-        TypeDefinition::Anonymous(TypeDefinitionImpl::new(None, constraints.into()))
+        TypeDefinition::Anonymous(TypeDefinitionImpl::new(None, constraints.into(), None))
     }
 
     /// Provides the underlying constraints of [`TypeDefinitionImpl`]
@@ -254,6 +266,22 @@ impl TypeDefinition {
             return Range::optional();
         }
         Range::required()
+    }
+}
+
+impl Display for TypeDefinition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            TypeDefinition::Named(named_type_def) => {
+                write!(f, "{}", named_type_def)
+            }
+            TypeDefinition::Anonymous(anonymous_type_def) => {
+                write!(f, "{}", anonymous_type_def)
+            }
+            TypeDefinition::BuiltIn(builtin_ype_def) => {
+                write!(f, "{}", builtin_ype_def)
+            }
+        }
     }
 }
 
@@ -291,14 +319,21 @@ pub struct TypeDefinitionImpl {
     // ```
     // For above example, `bar` will be saved as deferred type definition until we resolve the definition of `bar`
     is_deferred_type_def: bool,
+    // Represents the ISL type struct in string format, this will be used for violation messages
+    isl_type_struct: Option<String>,
 }
 
 impl TypeDefinitionImpl {
-    pub fn new(name: Option<String>, constraints: Vec<Constraint>) -> Self {
+    pub fn new(
+        name: Option<String>,
+        constraints: Vec<Constraint>,
+        isl_type_struct: Option<String>,
+    ) -> Self {
         Self {
             name,
             constraints,
             is_deferred_type_def: false,
+            isl_type_struct,
         }
     }
 
@@ -307,6 +342,7 @@ impl TypeDefinitionImpl {
             name: Some(name),
             constraints: vec![],
             is_deferred_type_def: true,
+            isl_type_struct: None,
         }
     }
 
@@ -319,6 +355,7 @@ impl TypeDefinitionImpl {
             name: Some(alias),
             constraints: self.constraints,
             is_deferred_type_def: self.is_deferred_type_def,
+            isl_type_struct: None,
         }
     }
 
@@ -368,12 +405,16 @@ impl TypeDefinitionImpl {
             constraints.push(constraint);
         }
 
+        let isl_struct = &isl_type.isl_type_struct.as_ref();
         // add `type: any` as a default type constraint if there is no type constraint found
         if !found_type_constraint {
             // set the isl type name for any error that is returned while parsing its constraints
             let isl_type_name = match type_name.to_owned() {
                 Some(name) => name,
-                None => "".to_owned(),
+                None => match isl_struct {
+                    None => "".to_owned(),
+                    Some(isl_type_struct) => isl_type_struct.to_owned().to_owned(),
+                },
             };
 
             let isl_constraint = IslConstraint::from_ion_element(
@@ -391,7 +432,11 @@ impl TypeDefinitionImpl {
             constraints.push(constraint);
         }
 
-        let type_def = TypeDefinitionImpl::new(type_name.to_owned(), constraints);
+        let type_def = TypeDefinitionImpl::new(
+            type_name.to_owned(),
+            constraints,
+            isl_type.isl_type_struct.to_owned(),
+        );
 
         // actual type id is the type id with respect to type store length
         let actual_type_id;
@@ -431,7 +476,7 @@ impl TypeValidator for TypeDefinitionImpl {
     fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
         let type_name = match self.name() {
-            None => "",
+            None => self.isl_type_struct.as_ref().unwrap(),
             Some(name) => name,
         };
         for constraint in self.constraints() {
@@ -445,9 +490,23 @@ impl TypeValidator for TypeDefinitionImpl {
         Err(Violation::with_violations(
             type_name,
             ViolationCode::TypeConstraintsUnsatisfied,
-            "value didn't satisfy type constraint(s)",
+            &"value didn't satisfy type constraint(s)".to_owned(),
             violations,
         ))
+    }
+}
+
+impl Display for TypeDefinitionImpl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let type_def_name = match &self.name {
+            None => match &self.isl_type_struct {
+                None => "",
+                Some(type_name) => type_name,
+            },
+            Some(type_name) => type_name,
+        };
+
+        write!(f, "{}", type_def_name)
     }
 }
 

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -21,10 +21,10 @@ impl Violation {
         }
     }
 
-    pub fn with_violations<A: AsRef<str>>(
+    pub fn with_violations<A: AsRef<str>, B: AsRef<str>>(
         constraint: A,
         code: ViolationCode,
-        message: A,
+        message: B,
         violations: Vec<Violation>,
     ) -> Self {
         Self {

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -147,9 +147,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
                 "".to_string(),
                 ion.to_string(),
                 true,
-                format!(
-                    "Type definition: {schema_type} does not exist in this schema"
-                ),
+                format!("Type definition: {schema_type} does not exist in this schema"),
             )
         }
     };

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -148,8 +148,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
                 ion.to_string(),
                 true,
                 format!(
-                    "Type definition: {} does not exist in this schema",
-                    schema_type
+                    "Type definition: {schema_type} does not exist in this schema"
                 ),
             )
         }
@@ -157,7 +156,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
 
     log!(
         "{}",
-        format!("got type definition for: {} successfully!", schema_type)
+        format!("got type definition for: {schema_type} successfully!")
     );
 
     // get Element from given ion text
@@ -171,7 +170,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
                 "".to_string(),
                 ion.to_string(),
                 true,
-                format!("Can not parse given Ion value: {} for validation", ion),
+                format!("Can not parse given Ion value: {ion} for validation"),
             )
         }
     };
@@ -186,7 +185,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
     let violation = match &result {
         Ok(_) => "".to_string(),
         Err(violation) => {
-            format!("{:#?}", violation)
+            format!("{violation:#?}")
         }
     };
 
@@ -195,7 +194,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
     let result: SchemaValidationResult = SchemaValidationResult::new(
         result.is_ok(),
         violation,
-        format!("{}", value),
+        format!("{value}"),
         false,
         "".to_string(),
     );


### PR DESCRIPTION
### Issue #102:

### Description of changes:
This PR works on adding ISL struct in the violation messages for anonymous type definitions. This adds more context in the violation message regarding where in the type definition the violation occurred.

### List of changes:

* adds `Display` for `TypeDefinition`
* adds `isl_type_struct` field in `IslTypeImpl` and `TypeDefinitionImpl` that represents ISL type struct in string format
* remove usage of `Debug` for violation messages and instead uses `Display`. (Change all the `{:?}` usage to `{}`)
* modifies tests accordingly

*Example of a violation message:*
Schema:
```
type::{
  name: one_of_type,
  one_of: [ { type: string, codepoint_length: range::[1, 10] }, decimal ],
}
```

Type to be validated: 
```
one_of_type
```

Ion value used for validation: 
```
1
```

New violation message changed with this PR:
```
Violation {
    constraint: "one_of_type",
    code: TypeConstraintsUnsatisfied,
    message: "value didn't satisfy type constraint(s)",
    violations: [
        Violation {
            constraint: "one_of",
            code: NoTypesMatched,
            message: "value matches none of the types",
            violations: [
                Violation {
                    constraint: "{type: string, codepoint_length: range::[1, 10]}",  // <--- gives a more precise location information
                    code: TypeConstraintsUnsatisfied,
                    message: "value didn't satisfy type constraint(s)",
                    violations: [
                        Violation {
                            constraint: "type_constraint",
                            code: TypeMismatched,
                            message: "expected type String, found Integer",
                            violations: [],
                        },
                        Violation {
                            constraint: "codepoint_length",
                            code: TypeMismatched,
                            message: "expected [String, Symbol] but found integer",
                            violations: [],
                        },
                    ],
                },
                Violation {
                    constraint: "type_constraint",
                    code: TypeMismatched,
                    message: "expected type Decimal, found Integer",
                    violations: [],
                },
            ],
        },
    ],
}
```

Previous violation message (prior tot his PR): 
```
Violation {
    constraint: "one_of_type",
    code: TypeConstraintsUnsatisfied,
    message: "value didn't satisfy type constraint(s)",
    violations: [
        Violation {
            constraint: "one_of",
            code: NoTypesMatched,
            message: "value matches none of the types",
            violations: [
                Violation {
                    constraint: "",
                    code: TypeConstraintsUnsatisfied,
                    message: "value didn't satisfy type constraint(s)",
                    violations: [
                        Violation {
                            constraint: "type_constraint",
                            code: TypeMismatched,
                            message: "expected type String, found Integer",
                            violations: [],
                        },
                        Violation {
                            constraint: "codepoint_length",
                            code: TypeMismatched,
                            message: "expected [String, Symbol] but found integer",
                            violations: [],
                        },
                    ],
                },
                Violation {
                    constraint: "type_constraint",
                    code: TypeMismatched,
                    message: "expected type Decimal, found Integer",
                    violations: [],
                },
            ],
        },
    ],
}
```
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
