### PR TITLE
adds changes to allow open content within schema and adds APIs to retrieve open content

### DIFF
--- a/ion-schema-tests-runner/tests/ion-schema-tests-1-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-1-0.rs
@@ -16,7 +16,6 @@ ion_schema_tests!(
         "constraints::scale::invalid::scale_must_be_an_integer_or_range__10_",
         "constraints::scale::invalid::scale_must_be_an_integer_or_range__11_",
         "constraints::scale::invalid::scale_must_be_an_integer_or_range__04_",
-        "constraints::unknown_constraint::",
         "constraints::valid_values::all_types::value_should_be_invalid_for_type_valid_values_all_types__04_",
         "schema::import::diamond_import::should_be_a_valid_schema",
         "schema::import::diamond_import::value_should_be_valid_for_type_diamond_import",

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -53,6 +53,7 @@ pub enum Constraint {
     TimestampOffset(TimestampOffsetConstraint),
     TimestampPrecision(TimestampPrecisionConstraint),
     Type(TypeConstraint),
+    Unknown(String, Element),
     Utf8ByteLength(Utf8ByteLengthConstraint),
     ValidValues(ValidValuesConstraint),
 }
@@ -334,6 +335,10 @@ impl Constraint {
                     valid_values: valid_values.values().to_owned(),
                 }))
             }
+            IslConstraint::Unknown(constraint_name, element) => Ok(Constraint::Unknown(
+                constraint_name.to_owned(),
+                element.to_owned(),
+            )),
         }
     }
 
@@ -379,6 +384,11 @@ impl Constraint {
                 utf8_byte_length.validate(value, type_store)
             }
             Constraint::ValidValues(valid_values) => valid_values.validate(value, type_store),
+            Constraint::Unknown(_, _) => {
+                // No op
+                // `Unknown` represents open content which can be ignored for validation
+                Ok(())
+            }
         }
     }
 }

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -35,6 +35,7 @@ pub enum IslConstraint {
     TimestampOffset(IslTimestampOffsetConstraint),
     TimestampPrecision(Range),
     Type(IslTypeRef),
+    Unknown(String, Element), // Unknown constraint is used to store open contents
     Utf8ByteLength(Range),
     ValidValues(IslValidValuesConstraint),
 }
@@ -446,12 +447,9 @@ impl IslConstraint {
                 RangeType::NonNegativeInteger,
             )?)),
             "valid_values" => Ok(IslConstraint::ValidValues(value.try_into()?)),
-            _ => Err(invalid_schema_error_raw(
-                "Type: ".to_owned()
-                    + type_name
-                    + " can not be built as constraint: "
-                    + constraint_name
-                    + " does not exist",
+            _ => Ok(IslConstraint::Unknown(
+                constraint_name.to_string(),
+                value.to_owned(),
             )),
         }
     }

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -103,7 +103,7 @@ impl IslTypeImpl {
         open_content
     }
 
-    pub fn is_open_content_allowed(&self) -> bool {
+    pub(crate) fn is_open_content_allowed(&self) -> bool {
         let mut open_content = true;
         if self.constraints.contains(&IslConstraint::ContentClosed) {
             open_content = false;

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -96,13 +96,8 @@ impl IslTypeImpl {
     pub fn open_content(&self) -> Vec<(String, Element)> {
         let mut open_content = vec![];
         for constraint in &self.constraints {
-            match constraint {
-                IslConstraint::Unknown(constraint_name, element) => {
-                    open_content.push((constraint_name.to_owned(), element.to_owned()))
-                }
-                _ => {
-                    // no op
-                }
+            if let IslConstraint::Unknown(constraint_name, element) = constraint {
+                open_content.push((constraint_name.to_owned(), element.to_owned()))
             }
         }
         open_content

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -44,7 +44,15 @@ impl IslType {
     }
 
     /// Verifies if the [IslType] allows open content or not
-    pub fn open_content(&self) -> bool {
+    pub fn is_open_content_allowed(&self) -> bool {
+        match &self {
+            IslType::Named(named_type) => named_type.is_open_content_allowed(),
+            IslType::Anonymous(anonymous_type) => anonymous_type.is_open_content_allowed(),
+        }
+    }
+
+    /// Provides open content that is there in the type definition
+    pub fn open_content(&self) -> Vec<(String, Element)> {
         match &self {
             IslType::Named(named_type) => named_type.open_content(),
             IslType::Anonymous(anonymous_type) => anonymous_type.open_content(),
@@ -85,7 +93,22 @@ impl IslTypeImpl {
         &self.constraints
     }
 
-    pub fn open_content(&self) -> bool {
+    pub fn open_content(&self) -> Vec<(String, Element)> {
+        let mut open_content = vec![];
+        for constraint in &self.constraints {
+            match constraint {
+                IslConstraint::Unknown(constraint_name, element) => {
+                    open_content.push((constraint_name.to_owned(), element.to_owned()))
+                }
+                _ => {
+                    // no op
+                }
+            }
+        }
+        open_content
+    }
+
+    pub fn is_open_content_allowed(&self) -> bool {
         let mut open_content = true;
         if self.constraints.contains(&IslConstraint::ContentClosed) {
             open_content = false;

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -86,15 +86,28 @@ pub mod util;
 /// Provides an internal representation of an schema file
 #[derive(Debug, Clone)]
 pub struct IslSchema {
-    // Represents all the IslImports inside the schema file.
-    // For more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#imports
+    /// Represents all the IslImports inside the schema file.
+    /// For more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#imports
     imports: Vec<IslImport>,
-    // Represents all the IslType defined in this schema file.
-    // For more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#type-definitions
+    /// Represents all the IslType defined in this schema file.
+    /// For more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#type-definitions
     types: Vec<IslType>,
-    // Represents all the inline IslImportTypes in this schema file.
+    /// Represents all the inline IslImportTypes in this schema file.
     inline_imported_types: Vec<IslImportType>,
-    // Represents open content as `Element`s
+    /// Represents open content as `Element`s
+    /// Note: This doesn't preserve the information about where the open content is placed in the schema file.
+    /// e.g. This method doesn't differentiate between following schemas with open content:
+    /// ```ion
+    /// $foo
+    /// $bar
+    /// type::{ name: foo, codepoint_length: 1 }
+    /// ```
+    ///
+    /// ```ion
+    /// type::{ name: foo, codepoint_length: 1 }
+    /// $foo
+    /// $bar
+    /// ```
     open_content: Vec<Element>,
 }
 

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -954,14 +954,11 @@ impl Resolver {
 
         for authority in &self.authorities {
             return match authority.elements(id) {
-                Err(error) => match error {
-                    IonSchemaError::IoError { source } => match source.kind() {
-                        ErrorKind::NotFound => continue,
-                        _ => Err(IonSchemaError::IoError { source }),
-                    },
-                    _ => Err(error),
-                },
                 Ok(schema_content) => self.isl_schema_from_elements(schema_content.into_iter(), id),
+                Err(IonSchemaError::IoError { source: e }) if e.kind() == ErrorKind::NotFound => {
+                    continue
+                }
+                Err(error) => Err(error),
             };
         }
         unresolvable_schema_error("Unable to load ISL model: ".to_owned() + id)

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -400,7 +400,7 @@ impl TypeDefinitionImpl {
                 isl_constraint,
                 type_store,
                 pending_types,
-                isl_type.open_content(),
+                isl_type.is_open_content_allowed(),
             )?;
             constraints.push(constraint);
         }


### PR DESCRIPTION
### Issue #6

### Description of changes:
This PR works on adding changes for allowing open content within schema and adds APIs to retrieve open content.

### List of changes:
* adds `open_content()` in `IslType` as well `IslSchema` to retrieve open content
* adds `load_isl_schema()` that load a schema content as an internal ISL model which can be programmatically manipulated
* adds related tests for open content
_Note_: `IslSchema#open_content()` only provides top level open content. For open content in type definition  added `IslType#open_content()`

*Test:*
- adds unit tests inside `system` and `isl` modules
- allows test files from `ion-schema-tests` to verify open content is allowed

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
