### PR TITLE
adds `IonPath` implementation for `Violation`

### DIFF
--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -1,3 +1,4 @@
+use crate::ion_path::{IonPath, IonPathElement};
 use crate::isl::isl_constraint::{IslConstraint, IslRegexConstraint};
 use crate::isl::isl_range::{Range, RangeImpl};
 use crate::isl::isl_type_reference::IslTypeRef;
@@ -26,7 +27,12 @@ pub trait ConstraintValidator {
     /// adding [Violation]s and/or [ViolationChild]ren to `Err(violation)`
     /// if the constraint is violated.
     /// Otherwise, if the value passes the validation against the constraint then returns `Ok(())`.
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult;
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult;
 }
 
 /// Defines schema Constraints
@@ -342,16 +348,25 @@ impl Constraint {
         }
     }
 
-    pub fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    pub fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         match self {
-            Constraint::AllOf(all_of) => all_of.validate(value, type_store),
-            Constraint::Annotations(annotations) => annotations.validate(value, type_store),
-            Constraint::AnyOf(any_of) => any_of.validate(value, type_store),
-            Constraint::ByteLength(byte_length) => byte_length.validate(value, type_store),
-            Constraint::CodepointLength(codepoint_length) => {
-                codepoint_length.validate(value, type_store)
+            Constraint::AllOf(all_of) => all_of.validate(value, type_store, ion_path),
+            Constraint::Annotations(annotations) => {
+                annotations.validate(value, type_store, ion_path)
             }
-            Constraint::Contains(contains) => contains.validate(value, type_store),
+            Constraint::AnyOf(any_of) => any_of.validate(value, type_store, ion_path),
+            Constraint::ByteLength(byte_length) => {
+                byte_length.validate(value, type_store, ion_path)
+            }
+            Constraint::CodepointLength(codepoint_length) => {
+                codepoint_length.validate(value, type_store, ion_path)
+            }
+            Constraint::Contains(contains) => contains.validate(value, type_store, ion_path),
             Constraint::ContentClosed => {
                 // No op
                 // `content: closed` does not work as a constraint by its own, it needs to be used with other container constraints
@@ -360,30 +375,34 @@ impl Constraint {
                 Ok(())
             }
             Constraint::ContainerLength(container_length) => {
-                container_length.validate(value, type_store)
+                container_length.validate(value, type_store, ion_path)
             }
-            Constraint::Element(element) => element.validate(value, type_store),
-            Constraint::Fields(fields) => fields.validate(value, type_store),
-            Constraint::Not(not) => not.validate(value, type_store),
-            Constraint::OneOf(one_of) => one_of.validate(value, type_store),
-            Constraint::Type(type_constraint) => type_constraint.validate(value, type_store),
-            Constraint::Occurs(occurs) => occurs.validate(value, type_store),
+            Constraint::Element(element) => element.validate(value, type_store, ion_path),
+            Constraint::Fields(fields) => fields.validate(value, type_store, ion_path),
+            Constraint::Not(not) => not.validate(value, type_store, ion_path),
+            Constraint::OneOf(one_of) => one_of.validate(value, type_store, ion_path),
+            Constraint::Type(type_constraint) => {
+                type_constraint.validate(value, type_store, ion_path)
+            }
+            Constraint::Occurs(occurs) => occurs.validate(value, type_store, ion_path),
             Constraint::OrderedElements(ordered_elements) => {
-                ordered_elements.validate(value, type_store)
+                ordered_elements.validate(value, type_store, ion_path)
             }
-            Constraint::Precision(precision) => precision.validate(value, type_store),
-            Constraint::Regex(regex) => regex.validate(value, type_store),
-            Constraint::Scale(scale) => scale.validate(value, type_store),
+            Constraint::Precision(precision) => precision.validate(value, type_store, ion_path),
+            Constraint::Regex(regex) => regex.validate(value, type_store, ion_path),
+            Constraint::Scale(scale) => scale.validate(value, type_store, ion_path),
             Constraint::TimestampOffset(timestamp_offset) => {
-                timestamp_offset.validate(value, type_store)
+                timestamp_offset.validate(value, type_store, ion_path)
             }
             Constraint::TimestampPrecision(timestamp_precision) => {
-                timestamp_precision.validate(value, type_store)
+                timestamp_precision.validate(value, type_store, ion_path)
             }
             Constraint::Utf8ByteLength(utf8_byte_length) => {
-                utf8_byte_length.validate(value, type_store)
+                utf8_byte_length.validate(value, type_store, ion_path)
             }
-            Constraint::ValidValues(valid_values) => valid_values.validate(value, type_store),
+            Constraint::ValidValues(valid_values) => {
+                valid_values.validate(value, type_store, ion_path)
+            }
             Constraint::Unknown(_, _) => {
                 // No op
                 // `Unknown` represents open content which can be ignored for validation
@@ -420,12 +439,17 @@ impl AllOfConstraint {
 }
 
 impl ConstraintValidator for AllOfConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
         let mut valid_types = vec![];
         for type_id in &self.type_ids {
             let type_def = type_store.get_type_by_id(*type_id).unwrap();
-            match type_def.validate(value, type_store) {
+            match type_def.validate(value, type_store, ion_path) {
                 Ok(_) => valid_types.push(type_id),
                 Err(violation) => violations.push(violation),
             }
@@ -439,6 +463,7 @@ impl ConstraintValidator for AllOfConstraint {
                     valid_types.len(),
                     self.type_ids.len()
                 ),
+                ion_path,
                 violations,
             ));
         }
@@ -473,12 +498,17 @@ impl AnyOfConstraint {
 }
 
 impl ConstraintValidator for AnyOfConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
         let mut valid_types = vec![];
         for type_id in &self.type_ids {
             let type_def = type_store.get_type_by_id(*type_id).unwrap();
-            match type_def.validate(value, type_store) {
+            match type_def.validate(value, type_store, ion_path) {
                 Ok(_) => valid_types.push(type_id),
                 Err(violation) => violations.push(violation),
             }
@@ -489,6 +519,7 @@ impl ConstraintValidator for AnyOfConstraint {
                 "any_of",
                 ViolationCode::NoTypesMatched,
                 "value matches none of the types",
+                ion_path,
                 violations,
             ));
         }
@@ -523,12 +554,17 @@ impl OneOfConstraint {
 }
 
 impl ConstraintValidator for OneOfConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
         let mut valid_types = vec![];
         for type_id in &self.type_ids {
             let type_def = type_store.get_type_by_id(*type_id).unwrap();
-            match type_def.validate(value, type_store) {
+            match type_def.validate(value, type_store, ion_path) {
                 Ok(_) => valid_types.push(type_id),
                 Err(violation) => violations.push(violation),
             }
@@ -539,6 +575,7 @@ impl ConstraintValidator for OneOfConstraint {
                 "one_of",
                 ViolationCode::NoTypesMatched,
                 "value matches none of the types",
+                ion_path,
                 violations,
             )),
             1 => Ok(()),
@@ -546,6 +583,7 @@ impl ConstraintValidator for OneOfConstraint {
                 "one_of",
                 ViolationCode::MoreThanOneTypeMatched,
                 format!("value matches {total_valid_types} types, expected 1"),
+                ion_path,
                 violations,
             )),
         }
@@ -577,9 +615,14 @@ impl NotConstraint {
 }
 
 impl ConstraintValidator for NotConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let type_def = type_store.get_type_by_id(self.type_id).unwrap();
-        let violation = type_def.validate(value, type_store);
+        let violation = type_def.validate(value, type_store, ion_path);
         match violation {
             Err(violation) => Ok(()),
             Ok(_) => {
@@ -588,6 +631,7 @@ impl ConstraintValidator for NotConstraint {
                     "not",
                     ViolationCode::TypeMatched,
                     "value unexpectedly matches type",
+                    ion_path,
                 ))
             }
         }
@@ -619,9 +663,14 @@ impl TypeConstraint {
 }
 
 impl ConstraintValidator for TypeConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let type_def = type_store.get_type_by_id(self.type_id).unwrap();
-        type_def.validate(value, type_store)
+        type_def.validate(value, type_store, ion_path)
     }
 }
 
@@ -643,7 +692,12 @@ impl OccursConstraint {
 }
 
 impl ConstraintValidator for OccursConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // No op
         // `occurs` does not work as a constraint by its own, it needs to be used with other constraints
         // e.g. `ordered_elements`, `fields`, etc.
@@ -682,26 +736,35 @@ impl OrderedElementsConstraint {
         type_def: &TypeDefinition,
         values_iter: &mut Peekable<Box<dyn Iterator<Item = &Element> + 'a>>,
         type_store: &TypeStore,
+        ion_path: &mut IonPath,
     ) -> ValidationResult {
         let occurs_range: Range = type_def.get_occurs_constraint("ordered_elements");
 
         // use this counter to keep track of valid values for given type_def
         let mut count: i64 = 0;
+        // use this index to keep track of Ion path for violation
+        let mut idx = 0;
 
         // consume elements to reach the minimum required values for this type
         while let Some(value) = values_iter.next_if(|v| !occurs_range.contains(&count.into())) {
             let schema_element: IonSchemaElement = value.into();
 
-            if type_def.is_valid(&schema_element, type_store) {
+            ion_path.add_parent(IonPathElement::IndexedElement { index: idx });
+
+            if type_def.is_valid(&schema_element, type_store, ion_path) {
                 count += 1;
             } else {
                 // there's not enough values of this expected type
                 return Err(Violation::new(
                     "ordered_elements",
                     ViolationCode::TypeMismatched,
-                    &format!("Expected {occurs_range} of type {type_def}: found {count}"),
+                    format!("Expected {occurs_range} of type {type_def}: found {count}"),
+                    ion_path,
                 ));
             }
+
+            ion_path.remove_last_parent();
+            idx += 1;
         }
 
         // greedily take as many values as we can of this type without going out
@@ -710,7 +773,7 @@ impl OrderedElementsConstraint {
             // don't consume it until we know it's valid for the type
             if let Some(value) = values_iter.peek() {
                 let schema_element: IonSchemaElement = (*value).into();
-                if type_def.is_valid(&schema_element, type_store) {
+                if type_def.is_valid(&schema_element, type_store, ion_path) {
                     let _ = values_iter.next(); // consume it as it is valid
                     count += 1;
                 } else {
@@ -727,7 +790,8 @@ impl OrderedElementsConstraint {
             return Err(Violation::new(
                 "ordered_elements",
                 ViolationCode::TypeMismatched,
-                &format!("Expected {occurs_range} of type {type_def}: found {count}"),
+                format!("Expected {occurs_range} of type {type_def}: found {count}"),
+                ion_path,
             ));
         }
 
@@ -737,7 +801,12 @@ impl OrderedElementsConstraint {
 }
 
 impl ConstraintValidator for OrderedElementsConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let violations: Vec<Violation> = vec![];
 
         // Create a peekable iterator for given sequence
@@ -755,6 +824,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
                                 format!("{}", element.ion_type())
                             }
                         ),
+                        ion_path,
                         violations,
                     ));
                 }
@@ -775,6 +845,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
                 type_def,
                 &mut values_iter,
                 type_store,
+                ion_path,
             )?;
         }
 
@@ -786,6 +857,7 @@ impl ConstraintValidator for OrderedElementsConstraint {
                 ViolationCode::TypeMismatched,
                 // unwrap as we already verified with peek that there is a value
                 format!("Unexpected type found {}", values_iter.next().unwrap()),
+                ion_path,
                 violations,
             ))
         } else {
@@ -834,12 +906,17 @@ impl FieldsConstraint {
 }
 
 impl ConstraintValidator for FieldsConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
 
         // get struct value
         let ion_struct = value
-            .expect_element_of_type(&[IonType::Struct], "fields")?
+            .expect_element_of_type(&[IonType::Struct], "fields", ion_path)?
             .as_struct()
             .unwrap();
 
@@ -850,7 +927,8 @@ impl ConstraintValidator for FieldsConstraint {
                     violations.push(Violation::new(
                         "fields",
                         ViolationCode::InvalidOpenContent,
-                        &format!("Found open content in the struct: {field_name}: {value}"),
+                        format!("Found open content in the struct: {field_name}: {value}"),
+                        ion_path,
                     ));
                 }
             }
@@ -860,6 +938,11 @@ impl ConstraintValidator for FieldsConstraint {
         for (field_name, type_id) in &self.fields {
             let type_def = type_store.get_type_by_id(*type_id).unwrap();
             let values: Vec<&Element> = ion_struct.get_all(field_name).collect();
+
+            // add parent value for current field in ion path
+            ion_path.add_parent(IonPathElement::Field {
+                name: field_name.to_owned(),
+            });
 
             // perform occurs validation for type_def for all values of the given field_name
             let occurs_range: Range = type_def.get_occurs_constraint("fields");
@@ -875,16 +958,20 @@ impl ConstraintValidator for FieldsConstraint {
                         field_name,
                         values.len()
                     ),
+                    ion_path,
                 ));
             }
 
             // verify if all the values for this field name are valid according to type_def
             for value in values {
                 let schema_element: IonSchemaElement = value.into();
-                if let Err(violation) = type_def.validate(&schema_element, type_store) {
+                if let Err(violation) = type_def.validate(&schema_element, type_store, ion_path) {
                     violations.push(violation);
                 }
             }
+
+            // remove current field from list of parents
+            ion_path.remove_last_parent();
         }
 
         // return error if there were any violation found during validation
@@ -893,6 +980,7 @@ impl ConstraintValidator for FieldsConstraint {
                 "fields",
                 ViolationCode::FieldsNotMatched,
                 "value didn't satisfy fields constraint",
+                ion_path,
                 violations,
             ));
         }
@@ -916,7 +1004,12 @@ impl ContainsConstraint {
 }
 
 impl ConstraintValidator for ContainsConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // Create a peekable iterator for given sequence
         let values: Vec<Element> = match &value {
             IonSchemaElement::SingleElement(element) => {
@@ -934,6 +1027,7 @@ impl ConstraintValidator for ContainsConstraint {
                                     format!("{}", element.ion_type())
                                 }
                             ),
+                            ion_path,
                         ));
                     }
                     Some(ion_sequence) => ion_sequence.iter().map(|a| a.to_owned()).collect(),
@@ -958,7 +1052,8 @@ impl ConstraintValidator for ContainsConstraint {
             return Err(Violation::new(
                 "contains",
                 ViolationCode::MissingValue,
-                &format!("{value} has missing value(s): {missing_values:?}"),
+                format!("{value} has missing value(s): {missing_values:?}"),
+                ion_path,
             ));
         }
 
@@ -984,7 +1079,12 @@ impl ContainerLengthConstraint {
 }
 
 impl ConstraintValidator for ContainerLengthConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get the size of given value container
         let size = match value {
             IonSchemaElement::SingleElement(element) => {
@@ -993,7 +1093,8 @@ impl ConstraintValidator for ContainerLengthConstraint {
                     return Err(Violation::new(
                         "container_length",
                         ViolationCode::TypeMismatched,
-                        &format!("expected a container found {element}"),
+                        format!("expected a container found {element}"),
+                        ion_path,
                     ));
                 }
 
@@ -1007,10 +1108,11 @@ impl ConstraintValidator for ContainerLengthConstraint {
                         return Err(Violation::new(
                             "container_length",
                             ViolationCode::TypeMismatched,
-                            &format!(
+                            format!(
                                 "expected a container (a list/sexp/struct) but found {}",
                                 element.ion_type()
                             ),
+                            ion_path,
                         ));
                     }
                 }
@@ -1026,7 +1128,8 @@ impl ConstraintValidator for ContainerLengthConstraint {
             return Err(Violation::new(
                 "container_length",
                 ViolationCode::InvalidLength,
-                &format!("expected container length {length_range} found {size}"),
+                format!("expected container length {length_range} found {size}"),
+                ion_path,
             ));
         }
 
@@ -1052,10 +1155,15 @@ impl ByteLengthConstraint {
 }
 
 impl ConstraintValidator for ByteLengthConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get the size of given bytes
         let size = value
-            .expect_element_of_type(&[IonType::Blob, IonType::Clob], "byte_length")?
+            .expect_element_of_type(&[IonType::Blob, IonType::Clob], "byte_length", ion_path)?
             .as_bytes()
             .unwrap()
             .len();
@@ -1068,7 +1176,8 @@ impl ConstraintValidator for ByteLengthConstraint {
             return Err(Violation::new(
                 "byte_length",
                 ViolationCode::InvalidLength,
-                &format!("expected byte length {length_range} found {size}"),
+                format!("expected byte length {length_range} found {size}"),
+                ion_path,
             ));
         }
 
@@ -1094,10 +1203,19 @@ impl CodepointLengthConstraint {
 }
 
 impl ConstraintValidator for CodepointLengthConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get the size of given string/symbol Unicode codepoints
         let size = value
-            .expect_element_of_type(&[IonType::String, IonType::Symbol], "codepoint_length")?
+            .expect_element_of_type(
+                &[IonType::String, IonType::Symbol],
+                "codepoint_length",
+                ion_path,
+            )?
             .as_str()
             .unwrap()
             .chars()
@@ -1111,7 +1229,8 @@ impl ConstraintValidator for CodepointLengthConstraint {
             return Err(Violation::new(
                 "codepoint_length",
                 ViolationCode::InvalidLength,
-                &format!("expected codepoint length {length_range} found {size}"),
+                format!("expected codepoint length {length_range} found {size}"),
+                ion_path,
             ));
         }
 
@@ -1144,7 +1263,12 @@ impl ElementConstraint {
 }
 
 impl ConstraintValidator for ElementConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
 
         // this type_id was validated while creating `ElementConstraint` hence the unwrap here is safe
@@ -1158,26 +1282,37 @@ impl ConstraintValidator for ElementConstraint {
                     return Err(Violation::new(
                         "element",
                         ViolationCode::TypeMismatched,
-                        &format!("expected a container but found {element}"),
+                        format!("expected a container but found {element}"),
+                        ion_path,
                     ));
                 }
 
                 // validate each element of the given value container
                 match element.ion_type() {
                     IonType::List | IonType::SExpression => {
-                        for val in element.as_sequence().unwrap().iter() {
+                        for (idx, val) in element.as_sequence().unwrap().iter().enumerate() {
+                            ion_path.add_parent(IonPathElement::IndexedElement { index: idx });
                             let schema_element: IonSchemaElement = val.into();
-                            if let Err(violation) = type_def.validate(&schema_element, type_store) {
+                            if let Err(violation) =
+                                type_def.validate(&schema_element, type_store, ion_path)
+                            {
                                 violations.push(violation);
                             }
+                            ion_path.remove_last_parent();
                         }
                     }
                     IonType::Struct => {
                         for (field_name, val) in element.as_struct().unwrap().iter() {
+                            ion_path.add_parent(IonPathElement::Field {
+                                name: field_name.text().unwrap().to_owned(),
+                            });
                             let schema_element: IonSchemaElement = val.into();
-                            if let Err(violation) = type_def.validate(&schema_element, type_store) {
+                            if let Err(violation) =
+                                type_def.validate(&schema_element, type_store, ion_path)
+                            {
                                 violations.push(violation);
                             }
+                            ion_path.remove_last_parent();
                         }
                     }
                     _ => {
@@ -1185,21 +1320,25 @@ impl ConstraintValidator for ElementConstraint {
                         return Err(Violation::new(
                             "element",
                             ViolationCode::TypeMismatched,
-                            &format!(
+                            format!(
                                 "expected a container (a list/sexp/struct) but found {}",
                                 element.ion_type()
                             ),
+                            ion_path,
                         ));
                     }
                 }
             }
             IonSchemaElement::Document(document) => {
-                for val in document {
+                for (idx, val) in document.iter().enumerate() {
+                    ion_path.add_parent(IonPathElement::IndexedElement { index: idx });
                     let schema_element: IonSchemaElement = val.into();
 
-                    if let Err(violation) = type_def.validate(&schema_element, type_store) {
+                    if let Err(violation) = type_def.validate(&schema_element, type_store, ion_path)
+                    {
                         violations.push(violation);
                     }
+                    ion_path.remove_last_parent();
                 }
             }
         }
@@ -1209,6 +1348,7 @@ impl ConstraintValidator for ElementConstraint {
                 "element",
                 ViolationCode::ElementMismatched,
                 "one or more elements don't satisfy element constraint",
+                ion_path,
                 violations,
             ));
         }
@@ -1260,6 +1400,7 @@ impl AnnotationsConstraint {
         value: &Element,
         type_store: &TypeStore,
         violations: Vec<Violation>,
+        ion_path: &mut IonPath,
     ) -> ValidationResult {
         let mut value_annotations = value
             .annotations()
@@ -1279,6 +1420,7 @@ impl AnnotationsConstraint {
                             "annotations",
                             ViolationCode::AnnotationMismatched,
                             "annotations don't match expectations",
+                            ion_path,
                         ));
                     }
                 } else if expected_annotation.value() == actual_annotation {
@@ -1290,6 +1432,7 @@ impl AnnotationsConstraint {
                     "annotations",
                     ViolationCode::AnnotationMismatched,
                     "annotations don't match expectations",
+                    ion_path,
                 ));
             }
         }
@@ -1304,6 +1447,7 @@ impl AnnotationsConstraint {
                     "Unexpected annotations found {}",
                     value_annotations.next().unwrap()
                 ),
+                ion_path,
                 violations,
             ));
         }
@@ -1316,6 +1460,7 @@ impl AnnotationsConstraint {
         value: &Element,
         type_store: &TypeStore,
         violations: Vec<Violation>,
+        ion_path: &mut IonPath,
     ) -> ValidationResult {
         // This will be used by a violation to to return all the missing annotations
         let mut missing_annotations: Vec<&Annotation> = vec![];
@@ -1340,6 +1485,7 @@ impl AnnotationsConstraint {
                 "annotations",
                 ViolationCode::MissingAnnotation,
                 format!("missing annotation(s): {missing_annotations:?}"),
+                ion_path,
                 violations,
             ));
         }
@@ -1357,6 +1503,7 @@ impl AnnotationsConstraint {
                 "annotations",
                 ViolationCode::UnexpectedAnnotation,
                 "found one or more unexpected annotations",
+                ion_path,
                 violations,
             ));
         }
@@ -1366,18 +1513,24 @@ impl AnnotationsConstraint {
 }
 
 impl ConstraintValidator for AnnotationsConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let violations: Vec<Violation> = vec![];
 
         match value {
             IonSchemaElement::SingleElement(element) => {
                 // validate annotations that have list-level `ordered` annotation
                 if self.is_ordered {
-                    return self.validate_ordered_annotations(element, type_store, violations);
+                    return self
+                        .validate_ordered_annotations(element, type_store, violations, ion_path);
                 }
 
                 // validate annotations that does not have list-level `ordered` annotation
-                self.validate_unordered_annotations(element, type_store, violations)
+                self.validate_unordered_annotations(element, type_store, violations, ion_path)
             }
             IonSchemaElement::Document(document) => {
                 // document type can not have annotations
@@ -1385,6 +1538,7 @@ impl ConstraintValidator for AnnotationsConstraint {
                     "annotations",
                     ViolationCode::AnnotationMismatched,
                     "annotations constraint is not applicable for document type",
+                    ion_path,
                 ))
             }
         }
@@ -1409,10 +1563,15 @@ impl PrecisionConstraint {
 }
 
 impl ConstraintValidator for PrecisionConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get precision of decimal value
         let value_precision = value
-            .expect_element_of_type(&[IonType::Decimal], "precision")?
+            .expect_element_of_type(&[IonType::Decimal], "precision", ion_path)?
             .as_decimal()
             .unwrap()
             .precision();
@@ -1425,7 +1584,8 @@ impl ConstraintValidator for PrecisionConstraint {
             return Err(Violation::new(
                 "precision",
                 ViolationCode::InvalidLength,
-                &format!("expected precision {precision_range} found {value_precision}"),
+                format!("expected precision {precision_range} found {value_precision}"),
+                ion_path,
             ));
         }
 
@@ -1451,10 +1611,15 @@ impl ScaleConstraint {
 }
 
 impl ConstraintValidator for ScaleConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get scale of decimal value
         let value_scale = value
-            .expect_element_of_type(&[IonType::Decimal], "precision")?
+            .expect_element_of_type(&[IonType::Decimal], "precision", ion_path)?
             .as_decimal()
             .unwrap()
             .scale();
@@ -1467,7 +1632,8 @@ impl ConstraintValidator for ScaleConstraint {
             return Err(Violation::new(
                 "scale",
                 ViolationCode::InvalidLength,
-                &format!("expected scale {scale_range} found {value_scale}"),
+                format!("expected scale {scale_range} found {value_scale}"),
+                ion_path,
             ));
         }
 
@@ -1495,10 +1661,15 @@ impl TimestampPrecisionConstraint {
 }
 
 impl ConstraintValidator for TimestampPrecisionConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get timestamp value
         let timestamp_value = value
-            .expect_element_of_type(&[IonType::Timestamp], "timestamp_precision")?
+            .expect_element_of_type(&[IonType::Timestamp], "timestamp_precision", ion_path)?
             .as_timestamp()
             .unwrap();
 
@@ -1510,11 +1681,12 @@ impl ConstraintValidator for TimestampPrecisionConstraint {
             return Err(Violation::new(
                 "precision",
                 ViolationCode::InvalidLength,
-                &format!(
+                format!(
                     "expected precision {} found {:?}",
                     precision_range,
                     timestamp_value.precision()
                 ),
+                ion_path,
             ));
         }
 
@@ -1562,7 +1734,12 @@ impl Display for ValidValuesConstraint {
 }
 
 impl ConstraintValidator for ValidValuesConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         match value {
             IonSchemaElement::SingleElement(value) => {
                 for valid_value in &self.valid_values {
@@ -1591,19 +1768,21 @@ impl ConstraintValidator for ValidValuesConstraint {
                 Err(Violation::new(
                     "valid_values",
                     ViolationCode::InvalidValue,
-                    &format!(
+                    format!(
                         "expected valid_values to be from {}, found {}",
                         &self, value
                     ),
+                    ion_path,
                 ))
             }
             IonSchemaElement::Document(document) => Err(Violation::new(
                 "valid_values",
                 ViolationCode::InvalidValue,
-                &format!(
+                format!(
                     "expected valid_values to be from {}, found {}",
                     &self, value
                 ),
+                ion_path,
             )),
         }
     }
@@ -1766,10 +1945,15 @@ impl RegexConstraint {
 }
 
 impl ConstraintValidator for RegexConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get string value and return violation if its not a string or symbol type
         let string_value = value
-            .expect_element_of_type(&[IonType::String, IonType::Symbol], "regex")?
+            .expect_element_of_type(&[IonType::String, IonType::Symbol], "regex", ion_path)?
             .as_str()
             .unwrap();
 
@@ -1783,7 +1967,8 @@ impl ConstraintValidator for RegexConstraint {
             return Err(Violation::new(
                 "regex",
                 ViolationCode::RegexMismatched,
-                &format!("{} doesn't match regex {}", value, self.expression),
+                format!("{} doesn't match regex {}", value, self.expression),
+                ion_path,
             ));
         }
 
@@ -1839,10 +2024,19 @@ impl Utf8ByteLengthConstraint {
 }
 
 impl ConstraintValidator for Utf8ByteLengthConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get the size of given bytes
         let size = value
-            .expect_element_of_type(&[IonType::String, IonType::Symbol], "utf8_byte_length")?
+            .expect_element_of_type(
+                &[IonType::String, IonType::Symbol],
+                "utf8_byte_length",
+                ion_path,
+            )?
             .as_str()
             .unwrap()
             .len();
@@ -1855,7 +2049,8 @@ impl ConstraintValidator for Utf8ByteLengthConstraint {
             return Err(Violation::new(
                 "utf8_byte_length",
                 ViolationCode::InvalidLength,
-                &format!("expected utf8 byte length {length_range} found {size}"),
+                format!("expected utf8 byte length {length_range} found {size}"),
+                ion_path,
             ));
         }
 
@@ -1881,10 +2076,15 @@ impl TimestampOffsetConstraint {
 }
 
 impl ConstraintValidator for TimestampOffsetConstraint {
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         // get timestamp value
         let timestamp_value = value
-            .expect_element_of_type(&[IonType::Timestamp], "timestamp_offset")?
+            .expect_element_of_type(&[IonType::Timestamp], "timestamp_offset", ion_path)?
             .as_timestamp()
             .unwrap();
 
@@ -1899,11 +2099,12 @@ impl ConstraintValidator for TimestampOffsetConstraint {
             return Err(Violation::new(
                 "timestamp_offset",
                 ViolationCode::InvalidLength,
-                &format!(
+                format!(
                     "expected timestamp offset from {:?} found {}",
                     formatted_valid_offsets,
                     <Option<i32> as Into<TimestampOffset>>::into(timestamp_value.offset())
                 ),
+                ion_path,
             ));
         }
 

--- a/ion-schema/src/ion_path.rs
+++ b/ion-schema/src/ion_path.rs
@@ -1,0 +1,90 @@
+use ion_rs::value::owned::Element;
+use ion_rs::value::Builder;
+use ion_rs::Symbol;
+use std::fmt;
+use std::fmt::Formatter;
+
+#[derive(Clone, PartialEq)]
+pub enum IonPathElement {
+    IndexedElement { index: usize },
+    Field { name: String },
+}
+
+// TODO: This can be removed once we have a complete Display for violation
+// This is currently used by schema sandbox to print nested violations
+impl fmt::Debug for IonPathElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            IonPathElement::IndexedElement { index } => {
+                write!(f, "{}", index)
+            }
+            IonPathElement::Field { name } => {
+                write!(f, ".{}", name)
+            }
+        }
+    }
+}
+
+impl fmt::Display for IonPathElement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self {
+            IonPathElement::IndexedElement { index } => {
+                write!(f, "[{}]", index)
+            }
+            IonPathElement::Field { name } => {
+                write!(f, ".{}", name)
+            }
+        }
+    }
+}
+
+#[derive(Default, Clone, PartialEq)]
+pub struct IonPath {
+    parents: Vec<IonPathElement>,
+}
+
+impl IonPath {
+    pub fn add_parent(&mut self, parent: IonPathElement) {
+        self.parents.push(parent);
+    }
+
+    pub fn remove_last_parent(&mut self) -> Option<IonPathElement> {
+        self.parents.pop()
+    }
+}
+
+impl Into<Element> for IonPath {
+    fn into(self) -> Element {
+        let mut ion_path = vec![];
+        for parent in &self.parents {
+            let element = match parent {
+                IonPathElement::IndexedElement { index } => Element::from(*index as i64),
+                IonPathElement::Field { name } => Element::from(Symbol::from(name.as_str())),
+            };
+            ion_path.push(element);
+        }
+        Element::new_sexp(ion_path.into_iter())
+    }
+}
+
+// TODO: This can be removed once we have a complete Display for violation
+// This is currently used by schema sandbox to print nested violations
+impl fmt::Debug for IonPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "./",)?;
+        for parent in &self.parents {
+            write!(f, "{}", parent)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for IonPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "./",)?;
+        for parent in &self.parents {
+            write!(f, "{}", parent)?;
+        }
+        Ok(())
+    }
+}

--- a/ion-schema/src/ion_path.rs
+++ b/ion-schema/src/ion_path.rs
@@ -16,10 +16,10 @@ impl fmt::Debug for IonPathElement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             IonPathElement::IndexedElement { index } => {
-                write!(f, "{}", index)
+                write!(f, "{index}")
             }
             IonPathElement::Field { name } => {
-                write!(f, ".{}", name)
+                write!(f, ".{name}")
             }
         }
     }
@@ -29,10 +29,10 @@ impl fmt::Display for IonPathElement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self {
             IonPathElement::IndexedElement { index } => {
-                write!(f, "[{}]", index)
+                write!(f, "[{index}]")
             }
             IonPathElement::Field { name } => {
-                write!(f, ".{}", name)
+                write!(f, ".{name}")
             }
         }
     }
@@ -73,7 +73,7 @@ impl fmt::Debug for IonPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "./",)?;
         for parent in &self.parents {
-            write!(f, "{}", parent)?;
+            write!(f, "{parent}")?;
         }
         Ok(())
     }
@@ -83,7 +83,7 @@ impl fmt::Display for IonPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "./",)?;
         for parent in &self.parents {
-            write!(f, "{}", parent)?;
+            write!(f, "{parent}")?;
         }
         Ok(())
     }

--- a/ion-schema/src/ion_path.rs
+++ b/ion-schema/src/ion_path.rs
@@ -32,27 +32,31 @@ impl fmt::Display for IonPathElement {
     }
 }
 
-/// Represents an IonPath associated with given Ion value for which the violation occurred.
-/// IonPath consists of IonPathElements where each element could either be an index value or a field name.
+/// Represents the path to the nested Ion value for which the violation occurred.
+/// An [IonPath] consists of [IonPathElement]s where each element could either be an index integer or a field name string. [IonPath]s are serialized as s-expressions.
 ///
-/// Note: IonPath is Displayed as an SExpression where each element of SExpression is either an index value or a field name.
-///
-/// Example of IonPath for an Ion value is as following:
+/// Here are some examples of serialized paths::
 /// ```ion
 /// {
 ///     greetings: [ "hello", "hi", "hey" ]
 /// }
 /// ```
 ///
-/// For an Ion value given as above if the violation occurred for Ion value "hi" then the associated
-/// IonPath would be as below:
+/// For an Ion value given as above if the violation occurred at the top level for given struct then
+/// the associated Ion Path would be as following:
 /// ```ion
-/// ( greetings 1 ) // here 1 represents the index of "hi" in the Ion list value
+/// () // this empty Ion Path suggests violation occurred at the top level
 /// ```
 ///
-/// For the same Ion value the IonPath associated with list value ["hello", "hi", "hey"]  would be as following:
+/// For the same Ion value the Ion Path associated with list value ["hello", "hi", "hey"]  would be as following:
 /// ```ion
-/// ( greetings ) // where `greetings` represents the field name for the list value
+/// ( greetings ) // this represents violation occurred at field with `greetings` as the field name for the list value
+/// ```
+///
+/// For an Ion value given as above if the violation occurred for Ion value "hi" then the associated
+/// Ion Path would be as below:
+/// ```ion
+/// ( greetings 1 ) // here 1 represents the index of "hi" in the Ion list value
 /// ```
 #[derive(Default, Clone, PartialEq, PartialOrd)]
 pub struct IonPath {

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code, unused_variables)]
 
 use crate::external::ion_rs::IonType;
+use crate::ion_path::IonPath;
 use crate::violation::{Violation, ViolationCode};
 use ion_rs::value::owned::Element;
 use ion_rs::value::reader::{element_reader, ElementReader};
@@ -24,6 +25,7 @@ macro_rules! try_to {
 pub mod authority;
 mod constraint;
 mod import;
+mod ion_path;
 pub mod isl;
 pub mod result;
 pub mod schema;
@@ -78,6 +80,7 @@ impl IonSchemaElement {
         &self,
         types: &[IonType],
         constraint_name: &str,
+        ion_path: &mut IonPath,
     ) -> Result<&Element, Violation> {
         match self {
             IonSchemaElement::SingleElement(element) => {
@@ -87,7 +90,8 @@ impl IonSchemaElement {
                     return Err(Violation::new(
                         constraint_name,
                         ViolationCode::TypeMismatched,
-                        &format!("expected {:?} but found {}", types, element.ion_type()),
+                        format!("expected {:?} but found {}", types, element.ion_type()),
+                        ion_path,
                     ));
                 }
                 // If it's an Element of an expected type, return a ref to it.
@@ -98,7 +102,8 @@ impl IonSchemaElement {
                 Err(Violation::new(
                     constraint_name,
                     ViolationCode::TypeMismatched,
-                    &format!("expected {types:?} but found document"),
+                    format!("expected {types:?} but found document"),
+                    ion_path,
                 ))
             }
         }

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -511,9 +511,9 @@ impl TypeValidator for TypeDefinitionImpl {
         &self,
         value: &IonSchemaElement,
         type_store: &TypeStore,
-        ion_pah: &mut IonPath,
+        ion_path: &mut IonPath,
     ) -> bool {
-        let violation = self.validate(value, type_store, ion_pah);
+        let violation = self.validate(value, type_store, ion_path);
         violation.is_ok()
     }
 

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -1,4 +1,5 @@
 use crate::constraint::Constraint;
+use crate::ion_path::IonPath;
 use crate::isl::isl_constraint::IslConstraint;
 use crate::isl::isl_range::Range;
 use crate::isl::isl_type::IslTypeImpl;
@@ -16,11 +17,21 @@ use std::rc::Rc;
 pub trait TypeValidator {
     /// If the specified value violates one or more of this type's constraints,
     /// returns `false`, otherwise `true`
-    fn is_valid(&self, value: &IonSchemaElement, type_store: &TypeStore) -> bool;
+    fn is_valid(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> bool;
 
     /// Returns `Err(violation)` with details as to which constraints were violated,
     /// otherwise returns `Ok(())` indicating no violations were found during the validation
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult;
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult;
 }
 
 // Provides a public facing schema type which has a reference to TypeStore
@@ -91,7 +102,7 @@ impl TypeRef {
         // convert given IonSchemaElement to an Element
         let schema_element: IonSchemaElement = value.into();
 
-        type_def.validate(&schema_element, &self.type_store)
+        type_def.validate(&schema_element, &self.type_store, &mut IonPath::default())
     }
 }
 
@@ -142,12 +153,22 @@ impl BuiltInTypeDefinition {
 }
 
 impl TypeValidator for BuiltInTypeDefinition {
-    fn is_valid(&self, value: &IonSchemaElement, type_store: &TypeStore) -> bool {
-        let violation = self.validate(value, type_store);
+    fn is_valid(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> bool {
+        let violation = self.validate(value, type_store, ion_path);
         violation.is_ok()
     }
 
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         match &self {
             BuiltInTypeDefinition::Atomic(ion_type, is_nullable) => {
                 // atomic types doesn't include document type
@@ -157,18 +178,20 @@ impl TypeValidator for BuiltInTypeDefinition {
                             return Err(Violation::new(
                                 "type_constraint",
                                 ViolationCode::InvalidNull,
-                                &format!("expected type {ion_type:?} doesn't allow null"),
+                                format!("expected type {ion_type:?} doesn't allow null"),
+                                ion_path,
                             ));
                         }
                         if element.ion_type() != *ion_type {
                             return Err(Violation::new(
                                 "type_constraint",
                                 ViolationCode::TypeMismatched,
-                                &format!(
+                                format!(
                                     "expected type {:?}, found {:?}",
                                     ion_type,
                                     element.ion_type()
                                 ),
+                                ion_path,
                             ));
                         }
 
@@ -177,7 +200,8 @@ impl TypeValidator for BuiltInTypeDefinition {
                     IonSchemaElement::Document(document) => Err(Violation::new(
                         "type_constraint",
                         ViolationCode::TypeMismatched,
-                        &format!("expected type {ion_type:?}, found document"),
+                        format!("expected type {ion_type:?}, found document"),
+                        ion_path,
                     )),
                 }
             }
@@ -189,16 +213,17 @@ impl TypeValidator for BuiltInTypeDefinition {
                         return Err(Violation::new(
                             "type_constraint",
                             ViolationCode::TypeMismatched,
-                            &format!(
+                            format!(
                                 "expected type document found {:?}",
                                 value.as_element().unwrap().ion_type()
                             ),
+                            ion_path,
                         ));
                     }
                     return Ok(());
                 }
                 // if it is not a document type do validation using the type definition
-                other_type.validate(value, type_store)
+                other_type.validate(value, type_store, ion_path)
             }
         }
     }
@@ -286,16 +311,30 @@ impl Display for TypeDefinition {
 }
 
 impl TypeValidator for TypeDefinition {
-    fn is_valid(&self, value: &IonSchemaElement, type_store: &TypeStore) -> bool {
-        let violation = self.validate(value, type_store);
+    fn is_valid(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> bool {
+        let violation = self.validate(value, type_store, ion_path);
         violation.is_ok()
     }
 
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         match self {
-            TypeDefinition::Named(named_type) => named_type.validate(value, type_store),
-            TypeDefinition::Anonymous(anonymous_type) => anonymous_type.validate(value, type_store),
-            TypeDefinition::BuiltIn(built_in_type) => built_in_type.validate(value, type_store),
+            TypeDefinition::Named(named_type) => named_type.validate(value, type_store, ion_path),
+            TypeDefinition::Anonymous(anonymous_type) => {
+                anonymous_type.validate(value, type_store, ion_path)
+            }
+            TypeDefinition::BuiltIn(built_in_type) => {
+                built_in_type.validate(value, type_store, ion_path)
+            }
         }
     }
 }
@@ -468,19 +507,29 @@ impl PartialEq for TypeDefinitionImpl {
 }
 
 impl TypeValidator for TypeDefinitionImpl {
-    fn is_valid(&self, value: &IonSchemaElement, type_store: &TypeStore) -> bool {
-        let violation = self.validate(value, type_store);
+    fn is_valid(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_pah: &mut IonPath,
+    ) -> bool {
+        let violation = self.validate(value, type_store, ion_pah);
         violation.is_ok()
     }
 
-    fn validate(&self, value: &IonSchemaElement, type_store: &TypeStore) -> ValidationResult {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
         let type_name = match self.name() {
             None => format!("{}", self.isl_type_struct.as_ref().unwrap()),
             Some(name) => name.to_owned(),
         };
         for constraint in self.constraints() {
-            if let Err(violation) = constraint.validate(value, type_store) {
+            if let Err(violation) = constraint.validate(value, type_store, ion_path) {
                 violations.push(violation);
             }
         }
@@ -491,6 +540,7 @@ impl TypeValidator for TypeDefinitionImpl {
             type_name,
             ViolationCode::TypeConstraintsUnsatisfied,
             "value didn't satisfy type constraint(s)",
+            ion_path,
             violations,
         ))
     }

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -1,3 +1,4 @@
+use crate::ion_path::IonPath;
 use std::fmt;
 use std::fmt::Formatter;
 use thiserror::Error;
@@ -8,15 +9,22 @@ pub struct Violation {
     constraint: String,  // represents the constraint that created this violation
     code: ViolationCode, // represents an error code that indicates the type of the violation
     message: String,     // represents the detailed error message for this violation
+    ion_path: IonPath,   // represents the path to Ion value for which violation occurred
     violations: Vec<Violation>,
 }
 
 impl Violation {
-    pub fn new<A: AsRef<str>>(constraint: A, code: ViolationCode, message: A) -> Self {
+    pub fn new<A: AsRef<str>, B: AsRef<str>>(
+        constraint: A,
+        code: ViolationCode,
+        message: B,
+        ion_path: &mut IonPath,
+    ) -> Self {
         Self {
             constraint: constraint.as_ref().to_owned(),
             code,
             message: message.as_ref().to_owned(),
+            ion_path: ion_path.to_owned(),
             violations: vec![],
         }
     }
@@ -25,12 +33,14 @@ impl Violation {
         constraint: A,
         code: ViolationCode,
         message: B,
+        ion_path: &mut IonPath,
         violations: Vec<Violation>,
     ) -> Self {
         Self {
             constraint: constraint.as_ref().to_owned(),
             code,
             message: message.as_ref().to_owned(),
+            ion_path: ion_path.to_owned(),
             violations,
         }
     }
@@ -40,6 +50,7 @@ impl Violation {
     }
 }
 
+// TODO: Implement Violation with proper indentation for the nested tree of violations
 impl fmt::Display for Violation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "A validation error occurred: {}", self.message)

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -183,6 +183,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
     let violation = match &result {
         Ok(_) => "".to_string(),
         Err(violation) => {
+            //TODO: Once we have a Display implementation with proper indentation for nested violations change the following
             format!("{violation:#?}")
         }
     };


### PR DESCRIPTION

### Issue #140:

### Description of changes:
This PR works on adding changes to add path information for an Ion value that was invalid and resulted into violation.

### List of changes:
* adds implementation of `IonPath` along with `IonPathElement`
* adds `Debug` implementation for `IonPath` as that will be sued for schema sandbox
* `Into<Element>` implementation helps serialize `IonPath` as an SExpression

### Example

## Schema
```
type::{
  name: customer,
  type: struct,
  fields: {
    addresses: {
      type: list,
      element: {
        type: struct,
        fields: {
          city: { type: string, codepoint_length: range::[8, max] },
          state: symbol
        }
      }
    }
  }
}
```

## Ion Value to be validated:
```
{
  addresses: [
    { city: "Seattle", state: WA },
    { city: "Portland", state: OR },
    { city: "San Francisco", state: CA }
  ]
}
```

## Output Violation (Using the deeply nested violation for example here):
```
Violation {
    constraint: "{type: string, codepoint_length: range::[8, max]}",
    code: TypeConstraintsUnsatisfied,
    message: "value didn't satisfy type constraint(s)",
    ion_path: ./.addresses[0].city,
    violations: [
        Violation {
            constraint: "codepoint_length",
            code: InvalidLength,
            message: "expected codepoint length range::[ 8, max ] found 7",
            ion_path: ./.addresses[0].city,
            violations: [],
        },
    ],
}
```
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
