### PR TITLE
adds initial implementation to support ISL 2.0

### DIFF
--- a/ion-schema-tests-runner/src/generator.rs
+++ b/ion-schema-tests-runner/src/generator.rs
@@ -5,7 +5,7 @@ use ion_rs::value::reader::element_reader;
 use ion_rs::value::reader::ElementReader;
 use ion_rs::value::IonElement;
 use ion_rs::IonType;
-use ion_schema::isl::IonSchemaLanguageVersion;
+use ion_schema::isl::IslVersion;
 use proc_macro2::{Literal, TokenStream, TokenTree};
 use quote::{format_ident, quote};
 use regex::Regex;
@@ -176,7 +176,7 @@ fn generate_test_cases_for_file(ctx: Context) -> TokenStream {
 }
 
 /// find ISL version from schema content
-fn find_isl_version(schema_content: &[Element]) -> IonSchemaLanguageVersion {
+fn find_isl_version(schema_content: &[Element]) -> IslVersion {
     // ISL version marker regex
     let isl_version_marker: Regex = Regex::new(r"^\$ion_schema_\d.*$").unwrap();
 
@@ -194,15 +194,15 @@ fn find_isl_version(schema_content: &[Element]) -> IonSchemaLanguageVersion {
         {
             // This implementation supports Ion Schema 1.0 and Ion Schema 2.0
             return match value.as_str().unwrap() {
-                "$ion_schema_1_0" => IonSchemaLanguageVersion::V1_0,
-                "$ion_schema_2_0" => IonSchemaLanguageVersion::V2_0,
+                "$ion_schema_1_0" => IslVersion::V1_0,
+                "$ion_schema_2_0" => IslVersion::V2_0,
                 _ => unimplemented!("Unsupported Ion Schema Language version: {}", value),
             };
         }
     }
 
     // default ISL version 1.0 if no version marker is found
-    IonSchemaLanguageVersion::V1_0
+    IslVersion::V1_0
 }
 
 /// Generates a test case to assert that some Ion text is or is not a valid ISL schema document.
@@ -245,13 +245,13 @@ fn generate_value_test_case(
 fn generate_invalid_type_case(
     description: &str,
     invalid_type_text: &str,
-    isl_version: &IonSchemaLanguageVersion,
+    isl_version: &IslVersion,
 ) -> TokenStream {
     let invalid_type_text_token = TokenTree::from(Literal::string(invalid_type_text));
     let test_name = format_ident!("{}", util::escape_to_ident(description));
     let version = match isl_version {
-        IonSchemaLanguageVersion::V1_0 => "$ion_schema_1_0",
-        IonSchemaLanguageVersion::V2_0 => "$ion_schema_2_0",
+        IslVersion::V1_0 => "$ion_schema_1_0",
+        IslVersion::V2_0 => "$ion_schema_2_0",
     };
     let isl_version = TokenTree::from(Literal::string(version));
     quote! {

--- a/ion-schema-tests-runner/tests/ion-schema-tests-1-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-1-0.rs
@@ -9,8 +9,6 @@ ion_schema_tests!(
         "constraints::occurs::invalid::occurs_for_a_field_must_be_a_positive_integer_or_a_non_empty__non_negative_integer_range__7_",
         "constraints::occurs::invalid::occurs_must_be_a_positive_integer_or_non_empty__non_negative_integer_range__06_",
         "constraints::occurs::invalid::occurs_range_must_be_a_valid__satisfiable_range__1_",
-        "constraints::scale::invalid::scale_must_be_an_integer_or_range__10_",
-        "constraints::scale::invalid::scale_must_be_an_integer_or_range__11_",
         "constraints::scale::invalid::scale_must_be_an_integer_or_range__04_",
         "constraints::valid_values::all_types::value_should_be_invalid_for_type_valid_values_all_types__04_",
         "schema::import::diamond_import::should_be_a_valid_schema",

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -3,7 +3,7 @@ use crate::isl::isl_constraint::{IslConstraintImpl, IslRegexConstraint};
 use crate::isl::isl_range::{Range, RangeImpl};
 use crate::isl::isl_type_reference::IslTypeRefImpl;
 use crate::isl::util::{Annotation, TimestampOffset, TimestampPrecision, ValidValue};
-use crate::isl::IonSchemaLanguageVersion;
+use crate::isl::IslVersion;
 use crate::nfa::{FinalState, NfaBuilder, NfaEvaluation};
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
@@ -221,7 +221,7 @@ impl Constraint {
 
     /// Resolves all ISL type references to corresponding [TypeId]s
     fn resolve_type_references_to_type_ids(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         type_references: &[IslTypeRefImpl],
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
@@ -229,19 +229,14 @@ impl Constraint {
         type_references
             .iter()
             .map(|t| {
-                IslTypeRefImpl::resolve_type_reference(
-                    isl_version.to_owned(),
-                    t,
-                    type_store,
-                    pending_types,
-                )
+                IslTypeRefImpl::resolve_type_reference(isl_version, t, type_store, pending_types)
             })
             .collect::<IonSchemaResult<Vec<TypeId>>>()
     }
 
     /// Parse an [IslConstraint] to a [Constraint]
     pub(crate) fn resolve_from_isl_constraint(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         isl_constraint: &IslConstraintImpl,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
@@ -346,7 +341,7 @@ impl Constraint {
                     .iter()
                     .map(|t| {
                         IslTypeRefImpl::resolve_type_reference(
-                            isl_version.to_owned(),
+                            isl_version,
                             t,
                             type_store,
                             pending_types,
@@ -700,7 +695,7 @@ impl OrderedElementsConstraint {
 
     /// Tries to create an [OrderedElements] constraint from the given Element
     fn resolve_from_isl_constraint(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         type_references: &[IslTypeRefImpl],
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
@@ -708,12 +703,7 @@ impl OrderedElementsConstraint {
         let resolved_types: Vec<TypeId> = type_references
             .iter()
             .map(|t| {
-                IslTypeRefImpl::resolve_type_reference(
-                    isl_version.to_owned(),
-                    t,
-                    type_store,
-                    pending_types,
-                )
+                IslTypeRefImpl::resolve_type_reference(isl_version, t, type_store, pending_types)
             })
             .collect::<IonSchemaResult<Vec<TypeId>>>()?;
         Ok(OrderedElementsConstraint::new(resolved_types))
@@ -889,7 +879,7 @@ impl FieldsConstraint {
 
     /// Tries to create an [Fields] constraint from the given Element
     fn resolve_from_isl_constraint(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         fields: &HashMap<String, IslTypeRefImpl>,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
@@ -898,13 +888,8 @@ impl FieldsConstraint {
         let resolved_fields: HashMap<String, TypeId> = fields
             .iter()
             .map(|(f, t)| {
-                IslTypeRefImpl::resolve_type_reference(
-                    isl_version.to_owned(),
-                    t,
-                    type_store,
-                    pending_types,
-                )
-                .map(|type_id| (f.to_owned(), type_id))
+                IslTypeRefImpl::resolve_type_reference(isl_version, t, type_store, pending_types)
+                    .map(|type_id| (f.to_owned(), type_id))
             })
             .collect::<IonSchemaResult<HashMap<String, TypeId>>>()?;
         Ok(FieldsConstraint::new(resolved_fields, open_content))

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -696,13 +696,21 @@ impl OrderedElementsConstraint {
 
     /// Tries to create an [OrderedElements] constraint from the given Element
     pub fn resolve_from_isl_constraint(
+        isl_version: IonSchemaLanguageVersion,
         type_references: &[IslTypeRef],
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
     ) -> IonSchemaResult<Self> {
         let resolved_types: Vec<TypeId> = type_references
             .iter()
-            .map(|t| IslTypeRef::resolve_type_reference(t, type_store, pending_types))
+            .map(|t| {
+                IslTypeRef::resolve_type_reference(
+                    isl_version.to_owned(),
+                    t,
+                    type_store,
+                    pending_types,
+                )
+            })
             .collect::<IonSchemaResult<Vec<TypeId>>>()?;
         Ok(OrderedElementsConstraint::new(resolved_types))
     }

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -1,7 +1,7 @@
 use crate::ion_path::{IonPath, IonPathElement};
 use crate::isl::isl_constraint::{IslConstraintImpl, IslRegexConstraint};
 use crate::isl::isl_range::{Range, RangeImpl};
-use crate::isl::isl_type_reference::IslTypeRef;
+use crate::isl::isl_type_reference::IslTypeRefImpl;
 use crate::isl::util::{Annotation, TimestampOffset, TimestampPrecision, ValidValue};
 use crate::isl::IonSchemaLanguageVersion;
 use crate::nfa::{FinalState, NfaBuilder, NfaEvaluation};
@@ -222,14 +222,14 @@ impl Constraint {
     /// Resolves all ISL type references to corresponding [TypeId]s
     fn resolve_type_references_to_type_ids(
         isl_version: IonSchemaLanguageVersion,
-        type_references: &[IslTypeRef],
+        type_references: &[IslTypeRefImpl],
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
     ) -> IonSchemaResult<Vec<TypeId>> {
         type_references
             .iter()
             .map(|t| {
-                IslTypeRef::resolve_type_reference(
+                IslTypeRefImpl::resolve_type_reference(
                     isl_version.to_owned(),
                     t,
                     type_store,
@@ -240,7 +240,7 @@ impl Constraint {
     }
 
     /// Parse an [IslConstraint] to a [Constraint]
-    pub fn resolve_from_isl_constraint(
+    pub(crate) fn resolve_from_isl_constraint(
         isl_version: IonSchemaLanguageVersion,
         isl_constraint: &IslConstraintImpl,
         type_store: &mut TypeStore,
@@ -292,7 +292,7 @@ impl Constraint {
                 ContainerLengthConstraint::new(isl_length.to_owned()),
             )),
             IslConstraintImpl::Element(type_reference) => {
-                let type_id = IslTypeRef::resolve_type_reference(
+                let type_id = IslTypeRefImpl::resolve_type_reference(
                     isl_version,
                     type_reference,
                     type_store,
@@ -321,7 +321,7 @@ impl Constraint {
                 Ok(Constraint::OneOf(OneOfConstraint::new(type_ids)))
             }
             IslConstraintImpl::Not(type_reference) => {
-                let type_id = IslTypeRef::resolve_type_reference(
+                let type_id = IslTypeRefImpl::resolve_type_reference(
                     isl_version,
                     type_reference,
                     type_store,
@@ -330,7 +330,7 @@ impl Constraint {
                 Ok(Constraint::Not(NotConstraint::new(type_id)))
             }
             IslConstraintImpl::Type(type_reference) => {
-                let type_id = IslTypeRef::resolve_type_reference(
+                let type_id = IslTypeRefImpl::resolve_type_reference(
                     isl_version,
                     type_reference,
                     type_store,
@@ -345,7 +345,7 @@ impl Constraint {
                 let type_ids: Vec<TypeId> = type_references
                     .iter()
                     .map(|t| {
-                        IslTypeRef::resolve_type_reference(
+                        IslTypeRefImpl::resolve_type_reference(
                             isl_version.to_owned(),
                             t,
                             type_store,
@@ -699,16 +699,16 @@ impl OrderedElementsConstraint {
     }
 
     /// Tries to create an [OrderedElements] constraint from the given Element
-    pub fn resolve_from_isl_constraint(
+    fn resolve_from_isl_constraint(
         isl_version: IonSchemaLanguageVersion,
-        type_references: &[IslTypeRef],
+        type_references: &[IslTypeRefImpl],
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
     ) -> IonSchemaResult<Self> {
         let resolved_types: Vec<TypeId> = type_references
             .iter()
             .map(|t| {
-                IslTypeRef::resolve_type_reference(
+                IslTypeRefImpl::resolve_type_reference(
                     isl_version.to_owned(),
                     t,
                     type_store,
@@ -888,9 +888,9 @@ impl FieldsConstraint {
     }
 
     /// Tries to create an [Fields] constraint from the given Element
-    pub fn resolve_from_isl_constraint(
+    fn resolve_from_isl_constraint(
         isl_version: IonSchemaLanguageVersion,
-        fields: &HashMap<String, IslTypeRef>,
+        fields: &HashMap<String, IslTypeRefImpl>,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
         open_content: bool, // Indicates if open content is allowed or not for the fields in the container
@@ -898,7 +898,7 @@ impl FieldsConstraint {
         let resolved_fields: HashMap<String, TypeId> = fields
             .iter()
             .map(|(f, t)| {
-                IslTypeRef::resolve_type_reference(
+                IslTypeRefImpl::resolve_type_reference(
                     isl_version.to_owned(),
                     t,
                     type_store,

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -378,7 +378,7 @@ mod v_2_0 {
 /// Represents schema constraints [IslConstraint] which stores IslTypeRef
 #[derive(Debug, Clone, PartialEq)]
 pub struct IslConstraint {
-    version: IonSchemaLanguageVersion,
+    pub(crate) version: IonSchemaLanguageVersion,
     pub(crate) constraint: IslConstraintImpl,
 }
 

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -2,7 +2,7 @@ use crate::isl::isl_import::IslImportType;
 use crate::isl::isl_range::{Range, RangeType};
 use crate::isl::isl_type_reference::IslTypeRefImpl;
 use crate::isl::util::{Annotation, TimestampOffset, ValidValue};
-use crate::isl::IonSchemaLanguageVersion;
+use crate::isl::IslVersion;
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
 };
@@ -22,7 +22,7 @@ pub mod v_1_0 {
     use crate::isl::isl_range::{IntegerRange, NonNegativeIntegerRange, Range, RangeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::isl::util::{Annotation, TimestampOffset, TimestampPrecision, ValidValue};
-    use crate::isl::IonSchemaLanguageVersion;
+    use crate::isl::IslVersion;
     use crate::result::IonSchemaResult;
     use ion_rs::value::owned::Element;
     use ion_rs::value::IonElement;
@@ -31,7 +31,7 @@ pub mod v_1_0 {
     // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
     pub fn type_constraint(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Type(isl_type.type_reference),
         )
     }
@@ -39,7 +39,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::AllOf] using the [IslTypeRef] referenced inside it
     pub fn all_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::AllOf(
                 isl_types
                     .into()
@@ -53,7 +53,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::AnyOf] using the [IslTypeRef] referenced inside it
     pub fn any_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::AnyOf(
                 isl_types
                     .into()
@@ -67,7 +67,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::OneOf] using the [IslTypeRef] referenced inside it
     pub fn one_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::OneOf(
                 isl_types
                     .into()
@@ -81,7 +81,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::OrderedElements] using the [IslTypeRef] referenced inside it
     pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::OrderedElements(
                 isl_types
                     .into()
@@ -95,7 +95,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: NonNegativeIntegerRange) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Precision(Range::NonNegativeInteger(precision)),
         )
     }
@@ -103,7 +103,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::Scale] using the range specified in it
     pub fn scale(scale: IntegerRange) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Scale(Range::Integer(scale)),
         )
     }
@@ -114,7 +114,7 @@ pub mod v_1_0 {
         I: Iterator<Item = (String, IslTypeRef)>,
     {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Fields(fields.map(|(s, t)| (s, t.type_reference)).collect()),
         )
     }
@@ -122,23 +122,20 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::Not] using the [IslTypeRef] referenced inside it
     pub fn not(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Not(isl_type.type_reference),
         )
     }
 
     /// Creates a [IslConstraint::Contains] using the [Element] specified inside it
     pub fn contains<A: Into<Vec<Element>>>(values: A) -> IslConstraint {
-        IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
-            IslConstraintImpl::Contains(values.into()),
-        )
+        IslConstraint::new(IslVersion::V1_0, IslConstraintImpl::Contains(values.into()))
     }
 
     /// Creates an [IslConstraint::ContainerLength] using the range specified in it
     pub fn container_length(length: NonNegativeIntegerRange) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::ContainerLength(Range::NonNegativeInteger(length)),
         )
     }
@@ -146,7 +143,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::ByteLength] using the range specified in it
     pub fn byte_length(length: RangeImpl<usize>) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::ByteLength(Range::NonNegativeInteger(length)),
         )
     }
@@ -154,7 +151,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::CodepointLength] using the range specified in it
     pub fn codepoint_length(length: RangeImpl<usize>) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::CodepointLength(Range::NonNegativeInteger(length)),
         )
     }
@@ -162,7 +159,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::TimestampPrecision] using the range specified in it
     pub fn timestamp_precision(precision: RangeImpl<TimestampPrecision>) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::TimestampPrecision(Range::TimestampPrecision(precision)),
         )
     }
@@ -170,7 +167,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::TimestampOffset] using the offset list specified in it
     pub fn timestamp_offset(offsets: Vec<TimestampOffset>) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::TimestampOffset(IslTimestampOffsetConstraint::new(offsets)),
         )
     }
@@ -178,7 +175,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::Utf8ByteLength] using the range specified in it
     pub fn utf8_byte_length(length: NonNegativeIntegerRange) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Utf8ByteLength(Range::NonNegativeInteger(length)),
         )
     }
@@ -186,7 +183,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it
     pub fn element(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Element(isl_type.type_reference),
         )
     }
@@ -210,7 +207,7 @@ pub mod v_1_0 {
             })
             .collect();
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Annotations(IslAnnotationsConstraint::new(
                 annotations_modifiers.contains(&"closed"),
                 annotations_modifiers.contains(&"ordered"),
@@ -224,7 +221,7 @@ pub mod v_1_0 {
         let valid_values: IonSchemaResult<Vec<ValidValue>> =
             values.iter().map(|e| e.try_into()).collect();
         Ok(IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::ValidValues(IslValidValuesConstraint {
                 valid_values: valid_values?,
             }),
@@ -234,7 +231,7 @@ pub mod v_1_0 {
     /// Creates a [IslConstraint::ValidValues] using the [Range] specified inside it
     pub fn valid_values_with_range(range: Range) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::ValidValues(IslValidValuesConstraint {
                 valid_values: vec![ValidValue::Range(range)],
             }),
@@ -244,7 +241,7 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::Regex] using the expression and flags (case_insensitive, multi_line)
     pub fn regex(case_insensitive: bool, multi_line: bool, expression: String) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             IslConstraintImpl::Regex(IslRegexConstraint::new(
                 case_insensitive,
                 multi_line,
@@ -263,7 +260,7 @@ pub mod v_2_0 {
     use crate::isl::isl_range::{NonNegativeIntegerRange, Range, RangeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::isl::util::{TimestampOffset, TimestampPrecision, ValidValue};
-    use crate::isl::IonSchemaLanguageVersion;
+    use crate::isl::IslVersion;
     use crate::result::IonSchemaResult;
     use ion_rs::value::owned::Element;
 
@@ -271,7 +268,7 @@ pub mod v_2_0 {
     // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
     pub fn type_constraint(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::Type(isl_type.type_reference),
         )
     }
@@ -279,7 +276,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::AllOf] using the [IslTypeRef] referenced inside it
     pub fn all_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::AllOf(
                 isl_types
                     .into()
@@ -293,7 +290,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::AnyOf] using the [IslTypeRef] referenced inside it
     pub fn any_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::AnyOf(
                 isl_types
                     .into()
@@ -307,7 +304,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::OneOf] using the [IslTypeRef] referenced inside it
     pub fn one_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::OneOf(
                 isl_types
                     .into()
@@ -321,7 +318,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::OrderedElements] using the [IslTypeRef] referenced inside it
     pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::OrderedElements(
                 isl_types
                     .into()
@@ -335,7 +332,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: NonNegativeIntegerRange) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::Precision(Range::NonNegativeInteger(precision)),
         )
     }
@@ -346,7 +343,7 @@ pub mod v_2_0 {
         I: Iterator<Item = (String, IslTypeRef)>,
     {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::Fields(fields.map(|(s, t)| (s, t.type_reference)).collect()),
         )
     }
@@ -354,23 +351,20 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::Not] using the [IslTypeRef] referenced inside it
     pub fn not(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::Not(isl_type.type_reference),
         )
     }
 
     /// Creates a [IslConstraint::Contains] using the [Element] specified inside it
     pub fn contains<A: Into<Vec<Element>>>(values: A) -> IslConstraint {
-        IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
-            IslConstraintImpl::Contains(values.into()),
-        )
+        IslConstraint::new(IslVersion::V2_0, IslConstraintImpl::Contains(values.into()))
     }
 
     /// Creates an [IslConstraint::ContainerLength] using the range specified in it
     pub fn container_length(length: NonNegativeIntegerRange) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::ContainerLength(Range::NonNegativeInteger(length)),
         )
     }
@@ -378,7 +372,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::ByteLength] using the range specified in it
     pub fn byte_length(length: RangeImpl<usize>) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::ByteLength(Range::NonNegativeInteger(length)),
         )
     }
@@ -386,7 +380,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::CodepointLength] using the range specified in it
     pub fn codepoint_length(length: RangeImpl<usize>) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::CodepointLength(Range::NonNegativeInteger(length)),
         )
     }
@@ -394,7 +388,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::TimestampPrecision] using the range specified in it
     pub fn timestamp_precision(precision: RangeImpl<TimestampPrecision>) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::TimestampPrecision(Range::TimestampPrecision(precision)),
         )
     }
@@ -402,7 +396,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::TimestampOffset] using the offset list specified in it
     pub fn timestamp_offset(offsets: Vec<TimestampOffset>) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::TimestampOffset(IslTimestampOffsetConstraint::new(offsets)),
         )
     }
@@ -410,7 +404,7 @@ pub mod v_2_0 {
     /// Creates an [IslConstraint::Utf8ByteLength] using the range specified in it
     pub fn utf8_byte_length(length: NonNegativeIntegerRange) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::Utf8ByteLength(Range::NonNegativeInteger(length)),
         )
     }
@@ -434,7 +428,7 @@ pub mod v_2_0 {
         let valid_values: IonSchemaResult<Vec<ValidValue>> =
             values.iter().map(|e| e.try_into()).collect();
         Ok(IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::ValidValues(IslValidValuesConstraint {
                 valid_values: valid_values?,
             }),
@@ -444,7 +438,7 @@ pub mod v_2_0 {
     /// Creates a [IslConstraint::ValidValues] using the [Range] specified inside it
     pub fn valid_values_with_range(range: Range) -> IslConstraint {
         IslConstraint::new(
-            IonSchemaLanguageVersion::V2_0,
+            IslVersion::V2_0,
             IslConstraintImpl::ValidValues(IslValidValuesConstraint {
                 valid_values: vec![ValidValue::Range(range)],
             }),
@@ -460,12 +454,12 @@ pub mod v_2_0 {
 /// Represents schema constraints [IslConstraint] which stores IslTypeRef
 #[derive(Debug, Clone, PartialEq)]
 pub struct IslConstraint {
-    pub(crate) version: IonSchemaLanguageVersion,
+    pub(crate) version: IslVersion,
     pub(crate) constraint: IslConstraintImpl,
 }
 
 impl IslConstraint {
-    pub(crate) fn new(version: IonSchemaLanguageVersion, constraint: IslConstraintImpl) -> Self {
+    pub(crate) fn new(version: IslVersion, constraint: IslConstraintImpl) -> Self {
         Self {
             constraint,
             version,
@@ -503,7 +497,7 @@ pub(crate) enum IslConstraintImpl {
 impl IslConstraintImpl {
     /// Parse constraints inside an [Element] to an [IslConstraint]
     pub fn from_ion_element(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         constraint_name: &str,
         value: &Element,
         type_name: &str,
@@ -790,7 +784,7 @@ impl IslConstraintImpl {
 
     // helper method for from_ion_element to get isl type references from given ion element
     fn isl_type_references_from_ion_element(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         value: &Element,
         inline_imported_types: &mut Vec<IslImportType>,
         constraint_name: &str,
@@ -812,15 +806,13 @@ impl IslConstraintImpl {
             .as_sequence()
             .unwrap()
             .iter()
-            .map(|e| {
-                IslTypeRefImpl::from_ion_element(isl_version.to_owned(), e, inline_imported_types)
-            })
+            .map(|e| IslTypeRefImpl::from_ion_element(isl_version, e, inline_imported_types))
             .collect::<IonSchemaResult<Vec<IslTypeRefImpl>>>()
     }
 
     // helper method for from_ion_element to get isl fields from given ion element
     fn isl_fields_from_ion_element(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         value: &Element,
         inline_imported_types: &mut Vec<IslImportType>,
     ) -> IonSchemaResult<HashMap<String, IslTypeRefImpl>> {
@@ -842,7 +834,7 @@ impl IslConstraintImpl {
             .unwrap()
             .iter()
             .map(|(f, v)| {
-                IslTypeRefImpl::from_ion_element(isl_version.to_owned(), v, inline_imported_types)
+                IslTypeRefImpl::from_ion_element(isl_version, v, inline_imported_types)
                     .map(|t| (f.text().unwrap().to_owned(), t))
             })
             .collect::<IonSchemaResult<HashMap<String, IslTypeRefImpl>>>()

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -22,6 +22,7 @@ pub mod v_1_0 {
     use crate::isl::isl_range::{IntegerRange, NonNegativeIntegerRange, Range, RangeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::isl::util::{Annotation, TimestampOffset, TimestampPrecision, ValidValue};
+    use crate::isl::IonSchemaLanguageVersion;
     use crate::result::IonSchemaResult;
     use ion_rs::value::owned::Element;
     use ion_rs::value::IonElement;
@@ -29,63 +30,82 @@ pub mod v_1_0 {
     /// Creates an [IslConstraint::Type] using the [IslTypeRef] referenced inside it
     // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
     pub fn type_constraint(isl_type: IslTypeRef) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::Type(isl_type.type_reference))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Type(isl_type.type_reference),
+        )
     }
 
     /// Creates an [IslConstraint::AllOf] using the [IslTypeRef] referenced inside it
     pub fn all_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::AllOf(
-            isl_types
-                .into()
-                .into_iter()
-                .map(|t| t.type_reference)
-                .collect(),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::AllOf(
+                isl_types
+                    .into()
+                    .into_iter()
+                    .map(|t| t.type_reference)
+                    .collect(),
+            ),
+        )
     }
 
     /// Creates an [IslConstraint::AnyOf] using the [IslTypeRef] referenced inside it
     pub fn any_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::AnyOf(
-            isl_types
-                .into()
-                .into_iter()
-                .map(|t| t.type_reference)
-                .collect(),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::AnyOf(
+                isl_types
+                    .into()
+                    .into_iter()
+                    .map(|t| t.type_reference)
+                    .collect(),
+            ),
+        )
     }
 
     /// Creates an [IslConstraint::OneOf] using the [IslTypeRef] referenced inside it
     pub fn one_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::OneOf(
-            isl_types
-                .into()
-                .into_iter()
-                .map(|t| t.type_reference)
-                .collect(),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::OneOf(
+                isl_types
+                    .into()
+                    .into_iter()
+                    .map(|t| t.type_reference)
+                    .collect(),
+            ),
+        )
     }
 
     /// Creates an [IslConstraint::OrderedElements] using the [IslTypeRef] referenced inside it
     pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::OrderedElements(
-            isl_types
-                .into()
-                .into_iter()
-                .map(|t| t.type_reference)
-                .collect(),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::OrderedElements(
+                isl_types
+                    .into()
+                    .into_iter()
+                    .map(|t| t.type_reference)
+                    .collect(),
+            ),
+        )
     }
 
     /// Creates an [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: NonNegativeIntegerRange) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::Precision(Range::NonNegativeInteger(
-            precision,
-        )))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Precision(Range::NonNegativeInteger(precision)),
+        )
     }
 
     /// Creates an [IslConstraint::Scale] using the range specified in it
     pub fn scale(scale: IntegerRange) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::Scale(Range::Integer(scale)))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Scale(Range::Integer(scale)),
+        )
     }
 
     /// Creates an [IslConstraint::Fields] using the field names and [IslTypeRef]s referenced inside it
@@ -93,66 +113,82 @@ pub mod v_1_0 {
     where
         I: Iterator<Item = (String, IslTypeRef)>,
     {
-        IslConstraint::new(IslConstraintImpl::Fields(
-            fields.map(|(s, t)| (s, t.type_reference)).collect(),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Fields(fields.map(|(s, t)| (s, t.type_reference)).collect()),
+        )
     }
 
     /// Creates an [IslConstraint::Not] using the [IslTypeRef] referenced inside it
     pub fn not(isl_type: IslTypeRef) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::Not(isl_type.type_reference))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Not(isl_type.type_reference),
+        )
     }
 
     /// Creates a [IslConstraint::Contains] using the [Element] specified inside it
     pub fn contains<A: Into<Vec<Element>>>(values: A) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::Contains(values.into()))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Contains(values.into()),
+        )
     }
 
     /// Creates an [IslConstraint::ContainerLength] using the range specified in it
     pub fn container_length(length: NonNegativeIntegerRange) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::ContainerLength(
-            Range::NonNegativeInteger(length),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::ContainerLength(Range::NonNegativeInteger(length)),
+        )
     }
 
     /// Creates an [IslConstraint::ByteLength] using the range specified in it
     pub fn byte_length(length: RangeImpl<usize>) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::ByteLength(Range::NonNegativeInteger(
-            length,
-        )))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::ByteLength(Range::NonNegativeInteger(length)),
+        )
     }
 
     /// Creates an [IslConstraint::CodepointLength] using the range specified in it
     pub fn codepoint_length(length: RangeImpl<usize>) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::CodepointLength(
-            Range::NonNegativeInteger(length),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::CodepointLength(Range::NonNegativeInteger(length)),
+        )
     }
 
     /// Creates an [IslConstraint::TimestampPrecision] using the range specified in it
     pub fn timestamp_precision(precision: RangeImpl<TimestampPrecision>) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::TimestampPrecision(
-            Range::TimestampPrecision(precision),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::TimestampPrecision(Range::TimestampPrecision(precision)),
+        )
     }
 
     /// Creates an [IslConstraint::TimestampOffset] using the offset list specified in it
     pub fn timestamp_offset(offsets: Vec<TimestampOffset>) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::TimestampOffset(
-            IslTimestampOffsetConstraint::new(offsets),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::TimestampOffset(IslTimestampOffsetConstraint::new(offsets)),
+        )
     }
 
     /// Creates an [IslConstraint::Utf8ByteLength] using the range specified in it
     pub fn utf8_byte_length(length: NonNegativeIntegerRange) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::Utf8ByteLength(
-            Range::NonNegativeInteger(length),
-        ))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Utf8ByteLength(Range::NonNegativeInteger(length)),
+        )
     }
 
     /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it
     pub fn element(isl_type: IslTypeRef) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::Element(isl_type.type_reference))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Element(isl_type.type_reference),
+        )
     }
 
     /// Creates an [IslConstraint::Annotations] using [str]s and [Element]s specified inside it
@@ -173,40 +209,48 @@ pub mod v_1_0 {
                 )
             })
             .collect();
-        IslConstraint::new(IslConstraintImpl::Annotations(
-            IslAnnotationsConstraint::new(
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Annotations(IslAnnotationsConstraint::new(
                 annotations_modifiers.contains(&"closed"),
                 annotations_modifiers.contains(&"ordered"),
                 annotations,
-            ),
-        ))
+            )),
+        )
     }
 
     /// Creates a [IslConstraint::ValidValues] using the [Element]s specified inside it
     pub fn valid_values_with_values(values: Vec<Element>) -> IonSchemaResult<IslConstraint> {
         let valid_values: IonSchemaResult<Vec<ValidValue>> =
             values.iter().map(|e| e.try_into()).collect();
-        Ok(IslConstraint::new(IslConstraintImpl::ValidValues(
-            IslValidValuesConstraint {
+        Ok(IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::ValidValues(IslValidValuesConstraint {
                 valid_values: valid_values?,
-            },
-        )))
+            }),
+        ))
     }
 
     /// Creates a [IslConstraint::ValidValues] using the [Range] specified inside it
     pub fn valid_values_with_range(range: Range) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::ValidValues(IslValidValuesConstraint {
-            valid_values: vec![ValidValue::Range(range)],
-        }))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::ValidValues(IslValidValuesConstraint {
+                valid_values: vec![ValidValue::Range(range)],
+            }),
+        )
     }
 
     /// Creates an [IslConstraint::Regex] using the expression and flags (case_insensitive, multi_line)
     pub fn regex(case_insensitive: bool, multi_line: bool, expression: String) -> IslConstraint {
-        IslConstraint::new(IslConstraintImpl::Regex(IslRegexConstraint::new(
-            case_insensitive,
-            multi_line,
-            expression,
-        )))
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V1_0,
+            IslConstraintImpl::Regex(IslRegexConstraint::new(
+                case_insensitive,
+                multi_line,
+                expression,
+            )),
+        )
     }
 }
 
@@ -334,12 +378,16 @@ mod v_2_0 {
 /// Represents schema constraints [IslConstraint] which stores IslTypeRef
 #[derive(Debug, Clone, PartialEq)]
 pub struct IslConstraint {
+    version: IonSchemaLanguageVersion,
     pub(crate) constraint: IslConstraintImpl,
 }
 
 impl IslConstraint {
-    pub(crate) fn new(constraint: IslConstraintImpl) -> Self {
-        Self { constraint }
+    pub(crate) fn new(version: IonSchemaLanguageVersion, constraint: IslConstraintImpl) -> Self {
+        Self {
+            constraint,
+            version,
+        }
     }
 }
 

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -255,7 +255,7 @@ pub mod v_1_0 {
 }
 
 /// Provides public facing APIs for constructing ISL constraints programmatically for ISL 2.0
-mod v_2_0 {
+pub mod v_2_0 {
     use crate::isl::isl_constraint::v_1_0;
     use crate::isl::isl_constraint::IslConstraint;
     use crate::isl::isl_range::{NonNegativeIntegerRange, Range, RangeImpl};

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -256,43 +256,88 @@ pub mod v_1_0 {
 
 /// Provides public facing APIs for constructing ISL constraints programmatically for ISL 2.0
 pub mod v_2_0 {
-    use crate::isl::isl_constraint::v_1_0;
     use crate::isl::isl_constraint::IslConstraint;
+    use crate::isl::isl_constraint::{
+        IslConstraintImpl, IslTimestampOffsetConstraint, IslValidValuesConstraint,
+    };
     use crate::isl::isl_range::{NonNegativeIntegerRange, Range, RangeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::isl::util::{TimestampOffset, TimestampPrecision, ValidValue};
+    use crate::isl::IonSchemaLanguageVersion;
     use crate::result::IonSchemaResult;
     use ion_rs::value::owned::Element;
 
     /// Creates an [IslConstraint::Type] using the [IslTypeRef] referenced inside it
     // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
     pub fn type_constraint(isl_type: IslTypeRef) -> IslConstraint {
-        v_1_0::type_constraint(isl_type)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::Type(isl_type.type_reference),
+        )
     }
 
     /// Creates an [IslConstraint::AllOf] using the [IslTypeRef] referenced inside it
     pub fn all_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
-        v_1_0::all_of(isl_types)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::AllOf(
+                isl_types
+                    .into()
+                    .into_iter()
+                    .map(|t| t.type_reference)
+                    .collect(),
+            ),
+        )
     }
 
     /// Creates an [IslConstraint::AnyOf] using the [IslTypeRef] referenced inside it
     pub fn any_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
-        v_1_0::any_of(isl_types)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::AnyOf(
+                isl_types
+                    .into()
+                    .into_iter()
+                    .map(|t| t.type_reference)
+                    .collect(),
+            ),
+        )
     }
 
     /// Creates an [IslConstraint::OneOf] using the [IslTypeRef] referenced inside it
     pub fn one_of<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
-        v_1_0::one_of(isl_types)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::OneOf(
+                isl_types
+                    .into()
+                    .into_iter()
+                    .map(|t| t.type_reference)
+                    .collect(),
+            ),
+        )
     }
 
     /// Creates an [IslConstraint::OrderedElements] using the [IslTypeRef] referenced inside it
     pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
-        v_1_0::ordered_elements(isl_types)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::OrderedElements(
+                isl_types
+                    .into()
+                    .into_iter()
+                    .map(|t| t.type_reference)
+                    .collect(),
+            ),
+        )
     }
 
     /// Creates an [IslConstraint::Precision] using the range specified in it
     pub fn precision(precision: NonNegativeIntegerRange) -> IslConstraint {
-        v_1_0::precision(precision)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::Precision(Range::NonNegativeInteger(precision)),
+        )
     }
 
     /// Creates an [IslConstraint::Fields] using the field names and [IslTypeRef]s referenced inside it
@@ -300,47 +345,74 @@ pub mod v_2_0 {
     where
         I: Iterator<Item = (String, IslTypeRef)>,
     {
-        v_1_0::fields(fields)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::Fields(fields.map(|(s, t)| (s, t.type_reference)).collect()),
+        )
     }
 
     /// Creates an [IslConstraint::Not] using the [IslTypeRef] referenced inside it
     pub fn not(isl_type: IslTypeRef) -> IslConstraint {
-        v_1_0::not(isl_type)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::Not(isl_type.type_reference),
+        )
     }
 
     /// Creates a [IslConstraint::Contains] using the [Element] specified inside it
     pub fn contains<A: Into<Vec<Element>>>(values: A) -> IslConstraint {
-        v_1_0::contains(values)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::Contains(values.into()),
+        )
     }
 
     /// Creates an [IslConstraint::ContainerLength] using the range specified in it
     pub fn container_length(length: NonNegativeIntegerRange) -> IslConstraint {
-        v_1_0::container_length(length)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::ContainerLength(Range::NonNegativeInteger(length)),
+        )
     }
 
     /// Creates an [IslConstraint::ByteLength] using the range specified in it
     pub fn byte_length(length: RangeImpl<usize>) -> IslConstraint {
-        v_1_0::byte_length(length)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::ByteLength(Range::NonNegativeInteger(length)),
+        )
     }
 
     /// Creates an [IslConstraint::CodepointLength] using the range specified in it
     pub fn codepoint_length(length: RangeImpl<usize>) -> IslConstraint {
-        v_1_0::codepoint_length(length)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::CodepointLength(Range::NonNegativeInteger(length)),
+        )
     }
 
     /// Creates an [IslConstraint::TimestampPrecision] using the range specified in it
     pub fn timestamp_precision(precision: RangeImpl<TimestampPrecision>) -> IslConstraint {
-        v_1_0::timestamp_precision(precision)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::TimestampPrecision(Range::TimestampPrecision(precision)),
+        )
     }
 
     /// Creates an [IslConstraint::TimestampOffset] using the offset list specified in it
     pub fn timestamp_offset(offsets: Vec<TimestampOffset>) -> IslConstraint {
-        v_1_0::timestamp_offset(offsets)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::TimestampOffset(IslTimestampOffsetConstraint::new(offsets)),
+        )
     }
 
     /// Creates an [IslConstraint::Utf8ByteLength] using the range specified in it
     pub fn utf8_byte_length(length: NonNegativeIntegerRange) -> IslConstraint {
-        v_1_0::utf8_byte_length(length)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::Utf8ByteLength(Range::NonNegativeInteger(length)),
+        )
     }
 
     /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it
@@ -361,12 +433,22 @@ pub mod v_2_0 {
     pub fn valid_values_with_values(values: Vec<Element>) -> IonSchemaResult<IslConstraint> {
         let valid_values: IonSchemaResult<Vec<ValidValue>> =
             values.iter().map(|e| e.try_into()).collect();
-        v_1_0::valid_values_with_values(values)
+        Ok(IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::ValidValues(IslValidValuesConstraint {
+                valid_values: valid_values?,
+            }),
+        ))
     }
 
     /// Creates a [IslConstraint::ValidValues] using the [Range] specified inside it
     pub fn valid_values_with_range(range: Range) -> IslConstraint {
-        v_1_0::valid_values_with_range(range)
+        IslConstraint::new(
+            IonSchemaLanguageVersion::V2_0,
+            IslConstraintImpl::ValidValues(IslValidValuesConstraint {
+                valid_values: vec![ValidValue::Range(range)],
+            }),
+        )
     }
 
     /// Creates an [IslConstraint::Regex] using the expression and flags (case_insensitive, multi_line)

--- a/ion-schema/src/isl/isl_range.rs
+++ b/ion-schema/src/isl/isl_range.rs
@@ -476,7 +476,8 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
             (TypedRangeBoundaryValue::Integer(v1), TypedRangeBoundaryValue::Max) => {
                 RangeImpl::range(v1, RangeBoundaryValue::Max)
             }
-            (TypedRangeBoundaryValue::Integer(Value(v1, _)), _) => {
+            (TypedRangeBoundaryValue::Integer(Value(v1, _)), _)
+            | (_, TypedRangeBoundaryValue::Integer(Value(v1, _))) => {
                 invalid_schema_error("Range boundaries must have the same types")
             }
             _ => unreachable!(
@@ -501,7 +502,7 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
             (TypedRangeBoundaryValue::NonNegativeInteger(v1), TypedRangeBoundaryValue::Max) => {
                 RangeImpl::range(v1, RangeBoundaryValue::Max)
             }
-            (TypedRangeBoundaryValue::NonNegativeInteger(Value(v1, _)), _) => {
+            (TypedRangeBoundaryValue::NonNegativeInteger(Value(v1, _)), _) | (_, TypedRangeBoundaryValue::NonNegativeInteger(Value(v1, _)))=> {
                 invalid_schema_error("Range boundaries should have same types")
             }
             _ => unreachable!(
@@ -526,7 +527,8 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
             (TypedRangeBoundaryValue::Number(v1), TypedRangeBoundaryValue::Max) => {
                 RangeImpl::range(v1, RangeBoundaryValue::Max)
             }
-            (TypedRangeBoundaryValue::Number(Value(v1, _)), _) => {
+            (TypedRangeBoundaryValue::Number(Value(v1, _)), _)
+            | (_, TypedRangeBoundaryValue::Number(Value(v1, _))) => {
                 invalid_schema_error("Range boundaries should have same types")
             }
             _ => unreachable!(
@@ -551,7 +553,7 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
             (TypedRangeBoundaryValue::TimestampPrecision(v1), TypedRangeBoundaryValue::Max) => {
                 RangeImpl::range(v1, RangeBoundaryValue::Max)
             }
-            (TypedRangeBoundaryValue::TimestampPrecision(Value(v1, _)), _) => {
+            (TypedRangeBoundaryValue::TimestampPrecision(Value(v1, _)), _) | (_, TypedRangeBoundaryValue::TimestampPrecision(Value(v1, _)))=> {
                 invalid_schema_error("Range boundaries should have same types")
             }
             _ => unreachable!(
@@ -576,7 +578,8 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
             (TypedRangeBoundaryValue::Decimal(v1), TypedRangeBoundaryValue::Max) => {
                 RangeImpl::range(v1, RangeBoundaryValue::Max)
             }
-            (TypedRangeBoundaryValue::Decimal(Value(v1, _)), _) => {
+            (TypedRangeBoundaryValue::Decimal(Value(v1, _)), _)
+            | (_, TypedRangeBoundaryValue::Decimal(Value(v1, _))) => {
                 invalid_schema_error("Range boundaries should have same types")
             }
             _ => unreachable!(
@@ -601,7 +604,8 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
             (TypedRangeBoundaryValue::Float(v1), TypedRangeBoundaryValue::Max) => {
                 RangeImpl::range(v1, RangeBoundaryValue::Max)
             }
-            (TypedRangeBoundaryValue::Float(Value(v1, _)), _) => {
+            (TypedRangeBoundaryValue::Float(Value(v1, _)), _)
+            | (_, TypedRangeBoundaryValue::Float(Value(v1, _))) => {
                 invalid_schema_error("Range boundaries should have same types")
             }
             _ => unreachable!(
@@ -645,7 +649,8 @@ impl<T: std::cmp::PartialOrd> RangeImpl<T> {
                 }
                 RangeImpl::range(v1, RangeBoundaryValue::Max)
             }
-            (TypedRangeBoundaryValue::Timestamp(Value(v1, _)), _) => {
+            (TypedRangeBoundaryValue::Timestamp(Value(v1, _)), _)
+            | (_, TypedRangeBoundaryValue::Timestamp(Value(v1, _))) => {
                 invalid_schema_error("Range boundaries should have same types")
             }
             _ => unreachable!(

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -8,7 +8,7 @@ use ion_rs::value::{IonElement, IonStruct};
 /// Provides public facing APIs for constructing ISL types programmatically for ISL 1.0
 pub mod v_1_0 {
     use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
-    use crate::isl::isl_type::{IslType, IslTypeImpl, IslTypeKind};
+    use crate::isl::isl_type::{IslType, IslTypeImpl};
 
     /// Creates a [IslType::Named] using the [IslConstraint] defined within it
     pub fn named_type<A: Into<String>, B: Into<Vec<IslConstraint>>>(
@@ -21,7 +21,7 @@ pub mod v_1_0 {
             .map(|c| c.constraint.to_owned())
             .collect();
         IslType::new(
-            IslTypeKind::Named(IslTypeImpl::new(Some(name.into()), isl_constraints, None)),
+            IslTypeImpl::new(Some(name.into()), isl_constraints, None),
             constraints,
         )
     }
@@ -33,10 +33,7 @@ pub mod v_1_0 {
             .iter()
             .map(|c| c.constraint.to_owned())
             .collect();
-        IslType::new(
-            IslTypeKind::Anonymous(IslTypeImpl::new(None, isl_constraints, None)),
-            constraints,
-        )
+        IslType::new(IslTypeImpl::new(None, isl_constraints, None), constraints)
     }
 }
 
@@ -62,70 +59,32 @@ pub mod v_2_0 {
 /// Represents a type in an ISL schema.
 #[derive(Debug, Clone, PartialEq)]
 pub struct IslType {
-    pub(crate) kind: IslTypeKind,
+    pub(crate) type_definition: IslTypeImpl,
     constraints: Vec<IslConstraint>,
 }
 
 impl IslType {
-    pub(crate) fn new(kind: IslTypeKind, constraints: Vec<IslConstraint>) -> Self {
-        Self { kind, constraints }
+    pub(crate) fn new(type_definition: IslTypeImpl, constraints: Vec<IslConstraint>) -> Self {
+        Self {
+            type_definition,
+            constraints,
+        }
     }
 
     /// Provides a name if the ISL type is named type definition
     /// Otherwise returns None
     pub fn name(&self) -> &Option<String> {
-        self.kind.name()
+        self.type_definition.name()
     }
 
     /// Provides open content that is there in the type definition
     pub fn open_content(&self) -> Vec<(String, Element)> {
-        self.kind.open_content()
+        self.type_definition.open_content()
     }
 
     /// Provides the underlying constraints of [IslType]
     pub fn constraints(&self) -> &[IslConstraint] {
         &self.constraints
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum IslTypeKind {
-    Named(IslTypeImpl),
-    Anonymous(IslTypeImpl),
-}
-
-impl IslTypeKind {
-    /// Provides a name if the ISL type is named type definition
-    /// Otherwise returns None
-    pub fn name(&self) -> &Option<String> {
-        match &self {
-            IslTypeKind::Named(named_isl_type) => named_isl_type.name(),
-            IslTypeKind::Anonymous(_) => &None,
-        }
-    }
-
-    /// Provides the underlying constraints of [IslTypeImpl]
-    pub fn constraints(&self) -> &[IslConstraintImpl] {
-        match &self {
-            IslTypeKind::Named(named_type) => named_type.constraints(),
-            IslTypeKind::Anonymous(anonymous_type) => anonymous_type.constraints(),
-        }
-    }
-
-    /// Verifies if the [IslType] allows open content or not
-    pub fn is_open_content_allowed(&self) -> bool {
-        match &self {
-            IslTypeKind::Named(named_type) => named_type.is_open_content_allowed(),
-            IslTypeKind::Anonymous(anonymous_type) => anonymous_type.is_open_content_allowed(),
-        }
-    }
-
-    /// Provides open content that is there in the type definition
-    pub fn open_content(&self) -> Vec<(String, Element)> {
-        match &self {
-            IslTypeKind::Named(named_type) => named_type.open_content(),
-            IslTypeKind::Anonymous(anonymous_type) => anonymous_type.open_content(),
-        }
     }
 }
 

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -1,6 +1,6 @@
 use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
 use crate::isl::isl_import::IslImportType;
-use crate::isl::IonSchemaLanguageVersion;
+use crate::isl::IslVersion;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use ion_rs::value::owned::{text_token, Element};
 use ion_rs::value::{IonElement, IonStruct};
@@ -141,7 +141,7 @@ impl IslTypeImpl {
 
     /// Parse constraints inside an [Element] to an [IslTypeImpl]
     pub fn from_owned_element(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         ion: &Element,
         inline_imported_types: &mut Vec<IslImportType>, // stores the inline_imports that are discovered while loading this ISL type
     ) -> IonSchemaResult<Self> {
@@ -201,7 +201,7 @@ impl IslTypeImpl {
             };
 
             let constraint = IslConstraintImpl::from_ion_element(
-                isl_version.to_owned(),
+                isl_version,
                 constraint_name,
                 value,
                 &isl_type_name,

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -1,5 +1,6 @@
 use crate::isl::isl_constraint::IslConstraint;
 use crate::isl::isl_import::IslImportType;
+use crate::isl::IonSchemaLanguageVersion;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use ion_rs::value::owned::{text_token, Element};
 use ion_rs::value::{IonElement, IonStruct};
@@ -113,6 +114,7 @@ impl IslTypeImpl {
 
     /// Parse constraints inside an [Element] to an [IslTypeImpl]
     pub fn from_owned_element(
+        isl_version: IonSchemaLanguageVersion,
         ion: &Element,
         inline_imported_types: &mut Vec<IslImportType>, // stores the inline_imports that are discovered while loading this ISL type
     ) -> IonSchemaResult<Self> {
@@ -172,6 +174,7 @@ impl IslTypeImpl {
             };
 
             let constraint = IslConstraint::from_ion_element(
+                isl_version.to_owned(),
                 constraint_name,
                 value,
                 &isl_type_name,

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -20,11 +20,10 @@ pub mod v_1_0 {
             .iter()
             .map(|c| c.constraint.to_owned())
             .collect();
-        IslType::new(IslTypeKind::Named(IslTypeImpl::new(
-            Some(name.into()),
-            isl_constraints,
-            None,
-        )))
+        IslType::new(
+            IslTypeKind::Named(IslTypeImpl::new(Some(name.into()), isl_constraints, None)),
+            constraints,
+        )
     }
 
     /// Creates a [IslType::Anonymous] using the [IslConstraint] defined within it
@@ -34,11 +33,10 @@ pub mod v_1_0 {
             .iter()
             .map(|c| c.constraint.to_owned())
             .collect();
-        IslType::new(IslTypeKind::Anonymous(IslTypeImpl::new(
-            None,
-            isl_constraints,
-            None,
-        )))
+        IslType::new(
+            IslTypeKind::Anonymous(IslTypeImpl::new(None, isl_constraints, None)),
+            constraints,
+        )
     }
 }
 
@@ -65,11 +63,12 @@ pub mod v_2_0 {
 #[derive(Debug, Clone, PartialEq)]
 pub struct IslType {
     pub(crate) kind: IslTypeKind,
+    constraints: Vec<IslConstraint>,
 }
 
 impl IslType {
-    pub(crate) fn new(kind: IslTypeKind) -> Self {
-        Self { kind }
+    pub(crate) fn new(kind: IslTypeKind, constraints: Vec<IslConstraint>) -> Self {
+        Self { kind, constraints }
     }
 
     /// Provides a name if the ISL type is named type definition
@@ -84,12 +83,8 @@ impl IslType {
     }
 
     /// Provides the underlying constraints of [IslType]
-    pub fn constraints(&self) -> Vec<IslConstraint> {
-        self.kind
-            .constraints()
-            .iter()
-            .map(|c| IslConstraint::new(c.to_owned()))
-            .collect()
+    pub fn constraints(&self) -> &[IslConstraint] {
+        &self.constraints
     }
 }
 

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -1,4 +1,4 @@
-use crate::isl::isl_constraint::IslConstraint;
+use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::IslTypeImpl;
 use crate::isl::IonSchemaLanguageVersion;
@@ -33,7 +33,12 @@ impl IslTypeRef {
 
     /// Creates a [IslTypeRef::Anonymous] using the [IonType] referenced inside it
     pub fn anonymous<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslTypeRef {
-        IslTypeRef::Anonymous(IslTypeImpl::new(None, constraints.into(), None))
+        let constraints = constraints.into();
+        let isl_constraints: Vec<IslConstraintImpl> = constraints
+            .iter()
+            .map(|c| c.constraint.to_owned())
+            .collect();
+        IslTypeRef::Anonymous(IslTypeImpl::new(None, isl_constraints, None))
     }
 
     /// Provides a string representing a definition of a nullable built in type reference

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -1,4 +1,3 @@
-use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::IslTypeImpl;
 use crate::isl::IonSchemaLanguageVersion;
@@ -12,11 +11,64 @@ use ion_rs::value::reader::{element_reader, ElementReader};
 use ion_rs::value::{IonElement, IonStruct};
 use ion_rs::IonType;
 
+/// Provides public facing APIs for constructing ISL type references programmatically for ISL 1.0
+pub mod v_1_0 {
+    use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
+    use crate::isl::isl_type::IslTypeImpl;
+    use crate::isl::isl_type_reference::{IslTypeRef, IslTypeRefImpl};
+
+    /// Creates a [IslTypeRef::Named] using the [IonType] referenced inside it
+    pub fn named_type_ref<A: Into<String>>(name: A) -> IslTypeRef {
+        IslTypeRef::new(IslTypeRefImpl::Named(name.into()))
+    }
+
+    /// Creates a [IslTypeRef::Anonymous] using the [IonType] referenced inside it
+    pub fn anonymous_type_ref<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslTypeRef {
+        let constraints = constraints.into();
+        let isl_constraints: Vec<IslConstraintImpl> = constraints
+            .iter()
+            .map(|c| c.constraint.to_owned())
+            .collect();
+        IslTypeRef::new(IslTypeRefImpl::Anonymous(IslTypeImpl::new(
+            None,
+            isl_constraints,
+            None,
+        )))
+    }
+}
+
+/// Provides public facing APIs for constructing ISL type references programmatically for ISL 2.0
+pub mod v_2_0 {
+    use crate::isl::isl_constraint::IslConstraint;
+    use crate::isl::isl_type_reference::{v_1_0, IslTypeRef};
+
+    /// Creates a [IslTypeRef::Named] using the [IonType] referenced inside it
+    pub fn named_type_ref<A: Into<String>>(name: A) -> IslTypeRef {
+        v_1_0::named_type_ref(name)
+    }
+
+    /// Creates a [IslTypeRef::Anonymous] using the [IonType] referenced inside it
+    pub fn anonymous_type_ref<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslTypeRef {
+        v_1_0::anonymous_type_ref(constraints)
+    }
+}
+
 /// Provides an internal representation of a schema type reference.
 /// The type reference grammar is defined in the [Ion Schema Spec]
 /// [Ion Schema spec]: `<https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#grammar>`
 #[derive(Debug, Clone, PartialEq)]
-pub enum IslTypeRef {
+pub struct IslTypeRef {
+    pub(crate) type_reference: IslTypeRefImpl,
+}
+
+impl IslTypeRef {
+    pub(crate) fn new(type_reference: IslTypeRefImpl) -> Self {
+        Self { type_reference }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum IslTypeRefImpl {
     /// Represents a reference to a named type (including aliases and built-in types)
     Named(String),
     /// Represents a type reference defined as an inlined import of a type from another schema
@@ -25,22 +77,7 @@ pub enum IslTypeRef {
     Anonymous(IslTypeImpl),
 }
 
-impl IslTypeRef {
-    /// Creates a [IslTypeRef::Named] using the [IonType] referenced inside it
-    pub fn named<A: Into<String>>(name: A) -> IslTypeRef {
-        IslTypeRef::Named(name.into())
-    }
-
-    /// Creates a [IslTypeRef::Anonymous] using the [IonType] referenced inside it
-    pub fn anonymous<A: Into<Vec<IslConstraint>>>(constraints: A) -> IslTypeRef {
-        let constraints = constraints.into();
-        let isl_constraints: Vec<IslConstraintImpl> = constraints
-            .iter()
-            .map(|c| c.constraint.to_owned())
-            .collect();
-        IslTypeRef::Anonymous(IslTypeImpl::new(None, isl_constraints, None))
-    }
-
+impl IslTypeRefImpl {
     /// Provides a string representing a definition of a nullable built in type reference
     // these are the built types that rae annotated with `nullable`
     fn get_nullable_type_reference_definition(type_ref_name: &str) -> IonSchemaResult<&str> {
@@ -95,13 +132,13 @@ impl IslTypeRef {
 
                 // check for nullable type reference
                 if value.annotations().any(|a| a.text() == Some("nullable")) {
-                    let built_in_type_def = IslTypeRef::get_nullable_type_reference_definition(type_name)?;
+                    let built_in_type_def = IslTypeRefImpl::get_nullable_type_reference_definition(type_name)?;
                     let value = &element_reader()
                         .read_one(built_in_type_def.as_bytes()).unwrap();
-                    return IslTypeRef::from_ion_element(isl_version, value, inline_imported_types);
+                    return IslTypeRefImpl::from_ion_element(isl_version, value, inline_imported_types);
                 }
 
-                Ok(IslTypeRef::Named(type_name.to_owned()))
+                Ok(IslTypeRefImpl::Named(type_name.to_owned()))
             }
             IonType::Struct => {
                 if value.is_null() {
@@ -117,7 +154,7 @@ impl IslTypeRef {
                 let value_struct = try_to!(value.as_struct());
                 // if the struct doesn't have an id field then it must be an anonymous type
                 if value_struct.get("id").is_none() {
-                    return Ok(IslTypeRef::Anonymous(IslTypeImpl::from_owned_element(isl_version, value, inline_imported_types)?))
+                    return Ok(IslTypeRefImpl::Anonymous(IslTypeImpl::from_owned_element(isl_version, value, inline_imported_types)?))
                 }
                 // if it is an inline import type store it as import type reference
                  let isl_import_type = match IslImport::from_ion_element(value)? {
@@ -132,7 +169,7 @@ impl IslTypeRef {
                 // if an inline import type is encountered add it in the inline_imports_types
                 // this will help resolve these inline imports before we start loading the schema types that uses them as reference
                 inline_imported_types.push(isl_import_type.to_owned());
-                Ok(IslTypeRef::TypeImport(isl_import_type))
+                Ok(IslTypeRefImpl::TypeImport(isl_import_type))
             },
             _ => Err(invalid_schema_error_raw(
                 "type reference can either be a symbol(For base/alias type reference) or a struct (for anonymous type reference)",
@@ -172,15 +209,15 @@ impl IslTypeRef {
     /// Resolves a type_reference into a [TypeId] using the type_store
     pub fn resolve_type_reference(
         isl_version: IonSchemaLanguageVersion,
-        type_reference: &IslTypeRef,
+        type_reference: &IslTypeRefImpl,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
     ) -> IonSchemaResult<TypeId> {
         match type_reference {
-            IslTypeRef::Named(alias) => {
-                IslTypeRef::get_type_id_from_type_name(alias, type_store, pending_types)
+            IslTypeRefImpl::Named(alias) => {
+                IslTypeRefImpl::get_type_id_from_type_name(alias, type_store, pending_types)
             }
-            IslTypeRef::Anonymous(isl_type) => {
+            IslTypeRefImpl::Anonymous(isl_type) => {
                 let type_id = pending_types.get_total_types(type_store);
                 let type_def = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
                     isl_version,
@@ -191,7 +228,7 @@ impl IslTypeRef {
                 // get the last added anonymous type's type_id for given anonymous type
                 Ok(type_id)
             }
-            IslTypeRef::TypeImport(isl_import_type) => {
+            IslTypeRefImpl::TypeImport(isl_import_type) => {
                 // verify if the inline import type already exists in the type_store
                 match type_store.get_type_id_by_name(isl_import_type.type_name()) {
                     None => unresolvable_schema_error(format!(

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -1,6 +1,6 @@
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::IslTypeImpl;
-use crate::isl::IonSchemaLanguageVersion;
+use crate::isl::IslVersion;
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, unresolvable_schema_error, IonSchemaResult,
 };
@@ -110,7 +110,7 @@ impl IslTypeRefImpl {
 
     /// Tries to create an [IslTypeRef] from the given Element
     pub fn from_ion_element(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         value: &Element,
         inline_imported_types: &mut Vec<IslImportType>,
     ) -> IonSchemaResult<Self> {
@@ -208,7 +208,7 @@ impl IslTypeRefImpl {
     // TODO: break match arms into helper methods as we add more constraints
     /// Resolves a type_reference into a [TypeId] using the type_store
     pub fn resolve_type_reference(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         type_reference: &IslTypeRefImpl,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -88,19 +88,19 @@ pub mod util;
 /// Represents Ion Schema Language Versions
 /// Currently it support v1.0 and v2.0
 #[derive(Debug, Clone, PartialEq, Copy)]
-pub enum IonSchemaLanguageVersion {
+pub enum IslVersion {
     V1_0,
     V2_0,
 }
 
-impl Display for IonSchemaLanguageVersion {
+impl Display for IslVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",
             match self {
-                IonSchemaLanguageVersion::V1_0 => "ISL 1.0",
-                IonSchemaLanguageVersion::V2_0 => "ISL 2.0",
+                IslVersion::V1_0 => "ISL 1.0",
+                IslVersion::V2_0 => "ISL 2.0",
             }
         )
     }
@@ -252,7 +252,7 @@ mod isl_tests {
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::v_1_0::*;
     use crate::isl::util::TimestampPrecision;
-    use crate::isl::IonSchemaLanguageVersion;
+    use crate::isl::IslVersion;
     use crate::result::IonSchemaResult;
     use ion_rs::types::decimal::*;
     use ion_rs::types::integer::Integer as IntegerValue;
@@ -267,7 +267,7 @@ mod isl_tests {
     // helper function to create NamedIslType for isl tests
     fn load_named_type(text: &str) -> IslType {
         let type_def = IslTypeImpl::from_owned_element(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             &element_reader()
                 .read_one(text.as_bytes())
                 .expect("parsing failed unexpectedly"),
@@ -277,7 +277,7 @@ mod isl_tests {
         let constraints = type_def
             .constraints()
             .iter()
-            .map(|c| IslConstraint::new(IonSchemaLanguageVersion::V1_0, c.to_owned()))
+            .map(|c| IslConstraint::new(IslVersion::V1_0, c.to_owned()))
             .collect();
         IslType::new(type_def, constraints)
     }
@@ -285,7 +285,7 @@ mod isl_tests {
     // helper function to create AnonymousIslType for isl tests
     fn load_anonymous_type(text: &str) -> IslType {
         let type_def = IslTypeImpl::from_owned_element(
-            IonSchemaLanguageVersion::V1_0,
+            IslVersion::V1_0,
             &element_reader()
                 .read_one(text.as_bytes())
                 .expect("parsing failed unexpectedly"),
@@ -295,7 +295,7 @@ mod isl_tests {
         let constraints = type_def
             .constraints()
             .iter()
-            .map(|c| IslConstraint::new(IonSchemaLanguageVersion::V1_0, c.to_owned()))
+            .map(|c| IslConstraint::new(IslVersion::V1_0, c.to_owned()))
             .collect();
         IslType::new(type_def, constraints)
     }

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -108,6 +108,8 @@ impl Display for IonSchemaLanguageVersion {
 
 //TODO: Implement ISL 2.0
 pub struct IslSchemaV2_0 {
+    /// Represents an id for the given ISL model
+    id: String,
     /// Represents the user defined reserved fields
     user_reserved_fields: UserReservedFields,
     /// Represents all the IslImports inside the schema file.
@@ -136,7 +138,8 @@ pub struct IslSchemaV2_0 {
 }
 
 impl IslSchemaV2_0 {
-    pub fn new(
+    pub fn new<A: AsRef<str>>(
+        id: A,
         user_reserved_fields: UserReservedFields,
         imports: Vec<IslImport>,
         types: Vec<IslType>,
@@ -144,12 +147,17 @@ impl IslSchemaV2_0 {
         open_content: Vec<Element>,
     ) -> Self {
         Self {
+            id: id.as_ref().to_owned(),
             user_reserved_fields,
             imports,
             types,
             inline_imported_types: inline_imports,
             open_content,
         }
+    }
+
+    pub fn id(&self) -> String {
+        self.id.to_owned()
     }
 
     pub fn imports(&self) -> &[IslImport] {
@@ -179,6 +187,8 @@ impl IslSchemaV2_0 {
 /// Provides an internal representation of an schema file
 #[derive(Debug, Clone)]
 pub struct IslSchemaV1_0 {
+    /// Represents an id for the given ISL model
+    id: String,
     /// Represents all the IslImports inside the schema file.
     /// For more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#imports
     imports: Vec<IslImport>,
@@ -205,18 +215,24 @@ pub struct IslSchemaV1_0 {
 }
 
 impl IslSchemaV1_0 {
-    pub fn new(
+    pub fn new<A: AsRef<str>>(
+        id: A,
         imports: Vec<IslImport>,
         types: Vec<IslType>,
         inline_imports: Vec<IslImportType>,
         open_content: Vec<Element>,
     ) -> Self {
         Self {
+            id: id.as_ref().to_owned(),
             imports,
             types,
             inline_imported_types: inline_imports,
             open_content,
         }
+    }
+
+    pub fn id(&self) -> String {
+        self.id.to_owned()
     }
 
     pub fn imports(&self) -> &[IslImport] {

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -17,11 +17,10 @@
 //!
 //! ## Example usage of `isl` module to create an `IslType`:
 //! ```
-//! use ion_schema::isl::{isl_type::IslType, isl_constraint::IslConstraintImpl, isl_type_reference::IslTypeRef};
+//! use ion_schema::isl::{isl_type::v_1_0::*, isl_constraint::v_1_0::*, isl_type_reference::v_1_0::*};
 //! use ion_schema::schema::Schema;
 //! use ion_schema::system::SchemaSystem;
 //! use std::path::Path;
-//! use ion_schema::isl::isl_constraint::v_1_0;
 //!
 //! // below code represents an ISL type:
 //! // type:: {
@@ -31,21 +30,21 @@
 //! //          { type: bool }
 //! //      ]
 //! //  }
-//! let isl_type = IslType::named(
+//! let isl_type = named_type(
 //!     // represents the `name` of the defined type
 //!     "my_type_name".to_owned(),
 //!     vec![
 //!         // represents the `type: int` constraint
-//!         v_1_0::type_constraint(
-//!             IslTypeRef::named("int")
+//!         type_constraint(
+//!             named_type_ref("int")
 //!         ),
 //!         // represents `all_of` with anonymous type `{ type: bool }` constraint
-//!         v_1_0::all_of(
+//!         all_of(
 //!             vec![
-//!                 IslTypeRef::anonymous(
+//!                 anonymous_type_ref(
 //!                     vec![
-//!                         v_1_0::type_constraint(
-//!                             IslTypeRef::named("bool")
+//!                         type_constraint(
+//!                             named_type_ref("bool")
 //!                         )
 //!                     ]
 //!                 )
@@ -241,7 +240,7 @@ impl IslSchemaV1_0 {
 
 #[cfg(test)]
 mod isl_tests {
-    use crate::isl::isl_constraint::v_1_0;
+    use crate::isl::isl_constraint::v_1_0::*;
     use crate::isl::isl_range::DecimalRange;
     use crate::isl::isl_range::FloatRange;
     use crate::isl::isl_range::IntegerRange;
@@ -250,8 +249,9 @@ mod isl_tests {
     use crate::isl::isl_range::TimestampPrecisionRange;
     use crate::isl::isl_range::TimestampRange;
     use crate::isl::isl_range::{Range, RangeBoundaryValue, RangeType};
-    use crate::isl::isl_type::{IslType, IslTypeImpl};
-    use crate::isl::isl_type_reference::IslTypeRef;
+    use crate::isl::isl_type::v_1_0::*;
+    use crate::isl::isl_type::{IslType, IslTypeImpl, IslTypeKind};
+    use crate::isl::isl_type_reference::v_1_0::*;
     use crate::isl::util::TimestampPrecision;
     use crate::isl::IonSchemaLanguageVersion;
     use crate::result::IonSchemaResult;
@@ -267,7 +267,7 @@ mod isl_tests {
 
     // helper function to create NamedIslType for isl tests
     fn load_named_type(text: &str) -> IslType {
-        IslType::Named(
+        IslType::new(IslTypeKind::Named(
             IslTypeImpl::from_owned_element(
                 IonSchemaLanguageVersion::V1_0,
                 &element_reader()
@@ -276,12 +276,12 @@ mod isl_tests {
                 &mut vec![],
             )
             .unwrap(),
-        )
+        ))
     }
 
     // helper function to create AnonymousIslType for isl tests
     fn load_anonymous_type(text: &str) -> IslType {
-        IslType::Anonymous(
+        IslType::new(IslTypeKind::Anonymous(
             IslTypeImpl::from_owned_element(
                 IonSchemaLanguageVersion::V1_0,
                 &element_reader()
@@ -290,7 +290,7 @@ mod isl_tests {
                 &mut vec![],
             )
             .unwrap(),
-        )
+        ))
     }
 
     #[test]
@@ -322,175 +322,176 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with single anonymous type
                 {type: any}
             "#),
-        IslType::anonymous([v_1_0::type_constraint(IslTypeRef::named("any"))])
+        anonymous_type([type_constraint(named_type_ref("any"))])
     ),
     case::type_constraint_with_nullable_annotation(
         load_anonymous_type(r#" // For a schema with `nullable` annotation`
                 {type: nullable::int}
             "#),
-        IslType::anonymous([v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::any_of([IslTypeRef::named("$null"), IslTypeRef::named("$int")]), v_1_0::type_constraint(IslTypeRef::named("$any"))]))])
+        anonymous_type([type_constraint(anonymous_type_ref([any_of([named_type_ref("$null"), named_type_ref("$int")]),type_constraint(named_type_ref("$any"))]))])
     ),
     case::type_constraint_with_named_type(
         load_named_type(r#" // For a schema with named type
                 type:: { name: my_int, type: int }
             "#),
-        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::named("int"))])
+        named_type("my_int", [type_constraint(named_type_ref("int"))])
     ),
     case::type_constraint_with_named_nullable_type(
         load_named_type(r#" // For a schema with named type
                 type:: { name: my_nullable_int, type: $int }
             "#),
-        IslType::named("my_nullable_int", [v_1_0::type_constraint(IslTypeRef::named("$int"))])
+        named_type("my_nullable_int", [type_constraint(named_type_ref("$int"))])
     ),
     case::type_constraint_with_self_reference_type(
         load_named_type(r#" // For a schema with self reference type
                 type:: { name: my_int, type: my_int }
             "#),
-        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::named("my_int"))])
+        named_type("my_int", [type_constraint(named_type_ref("my_int"))])
     ),
     case::type_constraint_with_nested_self_reference_type(
         load_named_type(r#" // For a schema with nested self reference type
                 type:: { name: my_int, type: { type: my_int } }
             "#),
-        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("my_int"))]))])
+        named_type("my_int", [type_constraint(anonymous_type_ref([type_constraint(named_type_ref("my_int"))]))])
     ),
     case::type_constraint_with_nested_type(
         load_named_type(r#" // For a schema with nested types
                 type:: { name: my_int, type: { type: int } }
             "#),
-        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]))])
+        named_type("my_int", [type_constraint(anonymous_type_ref([type_constraint(named_type_ref("int"))]))])
     ),
     case::type_constraint_with_nested_multiple_types(
         load_named_type(r#" // For a schema with nested multiple types
                 type:: { name: my_int, type: { type: int }, type: { type: my_int } }
             "#),
-        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])), v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("my_int"))]))])
+        named_type("my_int", [type_constraint(anonymous_type_ref([type_constraint(named_type_ref("int"))])), type_constraint(anonymous_type_ref([type_constraint(named_type_ref("my_int"))]))])
     ),
     case::all_of_constraint(
         load_anonymous_type(r#" // For a schema with all_of type as below:
                 { all_of: [{ type: int }] }
             "#),
-        IslType::anonymous([v_1_0::all_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])])])
+        anonymous_type([all_of([anonymous_type_ref([type_constraint(named_type_ref("int"))])])])
     ),
     case::any_of_constraint(
         load_anonymous_type(r#" // For a schema with any_of constraint as below:
                     { any_of: [{ type: int }, { type: decimal }] }
                 "#),
-        IslType::anonymous([v_1_0::any_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("decimal"))])])])
+        anonymous_type([any_of([anonymous_type_ref([type_constraint(named_type_ref("int"))]), anonymous_type_ref([type_constraint(named_type_ref("decimal"))])])])
     ),
     case::one_of_constraint(
         load_anonymous_type(r#" // For a schema with one_of constraint as below:
                     { one_of: [{ type: int }, { type: decimal }] }
                 "#),
-        IslType::anonymous([v_1_0::one_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("decimal"))])])])
+        anonymous_type([one_of([anonymous_type_ref([type_constraint(named_type_ref("int"))]), anonymous_type_ref([type_constraint(named_type_ref("decimal"))])])])
     ),
     case::not_constraint(
         load_anonymous_type(r#" // For a schema with not constraint as below:
                     { not: { type: int } }
                 "#),
-        IslType::anonymous([v_1_0::not(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]))])
+        anonymous_type([not(anonymous_type_ref([type_constraint(named_type_ref("int"))]))])
     ),
     case::ordered_elements_constraint(
         load_anonymous_type(r#" // For a schema with ordered_elements constraint as below:
                     { ordered_elements: [  symbol, { type: int },  ] }
                 "#),
-        IslType::anonymous([v_1_0::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])])])
+        anonymous_type([ordered_elements([named_type_ref("symbol"), anonymous_type_ref([type_constraint(named_type_ref("int"))])])])
     ),
     case::fields_constraint(
         load_anonymous_type(r#" // For a schema with fields constraint as below:
                     { fields: { name: string, id: int} }
                 "#),
-        IslType::anonymous([v_1_0::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
+        anonymous_type([fields(vec![("name".to_owned(), named_type_ref("string")), ("id".to_owned(), named_type_ref("int"))].into_iter())]),
     ),
     case::contains_constraint(
         load_anonymous_type(r#" // For a schema with contains constraint as below:
                     { contains: [true, 1, "hello"] }
                 "#),
-        IslType::anonymous([v_1_0::contains([true.into(), 1.into(), "hello".to_owned().into()])])
+        anonymous_type([contains([true.into(), 1.into(), "hello".to_owned().into()])])
     ),
     case::container_length_constraint(
         load_anonymous_type(r#" // For a schema with container_length constraint as below:
                     { container_length: 3 }
                 "#),
-        IslType::anonymous([v_1_0::container_length(3.into())])
+        anonymous_type([container_length(3.into())])
     ),
     case::byte_length_constraint(
         load_anonymous_type(r#" // For a schema with byte_length constraint as below:
                     { byte_length: 3 }
                 "#),
-        IslType::anonymous([v_1_0::byte_length(3.into())])
+        anonymous_type([byte_length(3.into())])
     ),
     case::codepoint_length_constraint(
         load_anonymous_type(r#" // For a schema with codepoint_length constraint as below:
                     { codepoint_length: 3 }
                 "#),
-        IslType::anonymous([v_1_0::codepoint_length(3.into())])
+        anonymous_type([codepoint_length(3.into())])
     ),
     case::element_constraint(
         load_anonymous_type(r#" // For a schema with element constraint as below:
                     { element: int }
                 "#),
-        IslType::anonymous([v_1_0::element(IslTypeRef::named("int"))])
+        anonymous_type([element(named_type_ref("int"))])
     ),
     case::annotations_constraint(
         load_anonymous_type(r#" // For a schema with annotations constraint as below:
                         { annotations: closed::[red, blue, green] }
                     "#),
-        IslType::anonymous([v_1_0::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])])
+        anonymous_type([annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])])
     ),
     case::precision_constraint(
         load_anonymous_type(r#" // For a schema with precision constraint as below:
                         { precision: 2 }
                     "#),
-        IslType::anonymous([v_1_0::precision(2.into())])
+        anonymous_type([precision(2.into())])
     ),
     case::scale_constraint(
         load_anonymous_type(r#" // For a schema with scale constraint as below:
                         { scale: 2 }
                     "#),
-        IslType::anonymous([v_1_0::scale(IntegerValue::I64(2).into())])
+        anonymous_type([scale(IntegerValue::I64(2).into())])
     ),
     case::timestamp_precision_constraint(
         load_anonymous_type(r#" // For a schema with timestamp_precision constraint as below:
                             { timestamp_precision: year }
                         "#),
-        IslType::anonymous([v_1_0::timestamp_precision("year".try_into().unwrap())])
+        anonymous_type([timestamp_precision("year".try_into().unwrap())])
     ),
     case::valid_values_constraint(
         load_anonymous_type(r#" // For a schema with valid_values constraint as below:
                         { valid_values: [2, 3.5, 5e7, "hello", hi] }
                     "#),
-        IslType::anonymous([v_1_0::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()])
+        anonymous_type([valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()])
     ),
     case::valid_values_with_range_constraint(
         load_anonymous_type(r#" // For a schema with valid_values constraint as below:
                         { valid_values: range::[1, 5.5] }
                     "#),
-        IslType::anonymous(
-            [v_1_0::valid_values_with_range(
-                NumberRange::new(
-                    Number::from(&IntegerValue::I64(1)),
-                    Number::from(&Decimal::new(55, -1))
-                ).unwrap().into())
-            ]
-        )
-    ),
+        anonymous_type(
+                [valid_values_with_range(
+                    NumberRange::new(
+                        Number::from(&IntegerValue::I64(1)),
+                        Number::from(&Decimal::new(55, -1))
+                    ).unwrap().into())
+                ]
+            )
+        ),
     case::utf8_byte_length_constraint(
         load_anonymous_type(r#" // For a schema with utf8_byte_length constraint as below:
                         { utf8_byte_length: 3 }
                     "#),
-        IslType::anonymous([v_1_0::utf8_byte_length(3.into())])
+        anonymous_type([utf8_byte_length(3.into())])
     ),
     case::regex_constraint(
         load_anonymous_type(r#" // For a schema with regex constraint as below:
                             { regex: "[abc]" }
                         "#),
-        IslType::anonymous(
-            [v_1_0::regex(
-                false, // case insensitive
-                false, // multiline
-                "[abc]".to_string()
-            )
+        anonymous_type(
+            [
+                regex(
+                    false, // case insensitive
+                    false, // multiline
+                    "[abc]".to_string()
+                )
             ]
         )
     ),
@@ -498,9 +499,9 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with timestamp_offset constraint as below:
                             { timestamp_offset: ["+00:00"] }
                         "#),
-        IslType::anonymous(
-        [v_1_0::timestamp_offset(vec!["+00:00".try_into().unwrap()])]
-    )
+        anonymous_type(
+            [timestamp_offset(vec!["+00:00".try_into().unwrap()])]
+        )
     )
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -184,7 +184,7 @@ impl IslSchema {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct IslSchemaImpl {
+pub(crate) struct IslSchemaImpl {
     /// Represents an id for the given ISL model
     id: String,
     /// Represents the user defined reserved fields

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -99,8 +99,8 @@ impl Display for IonSchemaLanguageVersion {
             f,
             "{}",
             match self {
-                IonSchemaLanguageVersion::V1_0 => "$ion_schema_1_0",
-                IonSchemaLanguageVersion::V2_0 => "$ion_schema_2_0",
+                IonSchemaLanguageVersion::V1_0 => "ISL 1.0",
+                IonSchemaLanguageVersion::V2_0 => "ISL 2.0",
             }
         )
     }

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -17,10 +17,11 @@
 //!
 //! ## Example usage of `isl` module to create an `IslType`:
 //! ```
-//! use ion_schema::isl::{isl_type::IslType, isl_constraint::IslConstraint, isl_type_reference::IslTypeRef};
+//! use ion_schema::isl::{isl_type::IslType, isl_constraint::IslConstraintImpl, isl_type_reference::IslTypeRef};
 //! use ion_schema::schema::Schema;
 //! use ion_schema::system::SchemaSystem;
 //! use std::path::Path;
+//! use ion_schema::isl::isl_constraint::v_1_0;
 //!
 //! // below code represents an ISL type:
 //! // type:: {
@@ -35,15 +36,15 @@
 //!     "my_type_name".to_owned(),
 //!     vec![
 //!         // represents the `type: int` constraint
-//!         IslConstraint::type_constraint(
+//!         v_1_0::type_constraint(
 //!             IslTypeRef::named("int")
 //!         ),
 //!         // represents `all_of` with anonymous type `{ type: bool }` constraint
-//!         IslConstraint::all_of(
+//!         v_1_0::all_of(
 //!             vec![
 //!                 IslTypeRef::anonymous(
 //!                     vec![
-//!                         IslConstraint::type_constraint(
+//!                         v_1_0::type_constraint(
 //!                             IslTypeRef::named("bool")
 //!                         )
 //!                     ]
@@ -240,7 +241,7 @@ impl IslSchemaV1_0 {
 
 #[cfg(test)]
 mod isl_tests {
-    use crate::isl::isl_constraint::IslConstraint;
+    use crate::isl::isl_constraint::v_1_0;
     use crate::isl::isl_range::DecimalRange;
     use crate::isl::isl_range::FloatRange;
     use crate::isl::isl_range::IntegerRange;
@@ -321,152 +322,152 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with single anonymous type
                 {type: any}
             "#),
-        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::named("any"))])
+        IslType::anonymous([v_1_0::type_constraint(IslTypeRef::named("any"))])
     ),
     case::type_constraint_with_nullable_annotation(
         load_anonymous_type(r#" // For a schema with `nullable` annotation`
                 {type: nullable::int}
             "#),
-        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::any_of([IslTypeRef::named("$null"), IslTypeRef::named("$int")]), IslConstraint::type_constraint(IslTypeRef::named("$any"))]))])
+        IslType::anonymous([v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::any_of([IslTypeRef::named("$null"), IslTypeRef::named("$int")]), v_1_0::type_constraint(IslTypeRef::named("$any"))]))])
     ),
     case::type_constraint_with_named_type(
         load_named_type(r#" // For a schema with named type
                 type:: { name: my_int, type: int }
             "#),
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::named("int"))])
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::named("int"))])
     ),
     case::type_constraint_with_named_nullable_type(
         load_named_type(r#" // For a schema with named type
                 type:: { name: my_nullable_int, type: $int }
             "#),
-        IslType::named("my_nullable_int", [IslConstraint::type_constraint(IslTypeRef::named("$int"))])
+        IslType::named("my_nullable_int", [v_1_0::type_constraint(IslTypeRef::named("$int"))])
     ),
     case::type_constraint_with_self_reference_type(
         load_named_type(r#" // For a schema with self reference type
                 type:: { name: my_int, type: my_int }
             "#),
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::named("my_int"))])
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::named("my_int"))])
     ),
     case::type_constraint_with_nested_self_reference_type(
         load_named_type(r#" // For a schema with nested self reference type
                 type:: { name: my_int, type: { type: my_int } }
             "#),
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("my_int"))]))])
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("my_int"))]))])
     ),
     case::type_constraint_with_nested_type(
         load_named_type(r#" // For a schema with nested types
                 type:: { name: my_int, type: { type: int } }
             "#),
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]))])
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]))])
     ),
     case::type_constraint_with_nested_multiple_types(
         load_named_type(r#" // For a schema with nested multiple types
                 type:: { name: my_int, type: { type: int }, type: { type: my_int } }
             "#),
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))])), IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::Type(IslTypeRef::named("my_int"))]))])
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])), v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("my_int"))]))])
     ),
     case::all_of_constraint(
         load_anonymous_type(r#" // For a schema with all_of type as below:
                 { all_of: [{ type: int }] }
             "#),
-        IslType::anonymous([IslConstraint::all_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))])])])
+        IslType::anonymous([v_1_0::all_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])])])
     ),
     case::any_of_constraint(
         load_anonymous_type(r#" // For a schema with any_of constraint as below:
                     { any_of: [{ type: int }, { type: decimal }] }
                 "#),
-        IslType::anonymous([IslConstraint::any_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("decimal"))])])])
+        IslType::anonymous([v_1_0::any_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("decimal"))])])])
     ),
     case::one_of_constraint(
         load_anonymous_type(r#" // For a schema with one_of constraint as below:
                     { one_of: [{ type: int }, { type: decimal }] }
                 "#),
-        IslType::anonymous([IslConstraint::one_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("decimal"))])])])
+        IslType::anonymous([v_1_0::one_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("decimal"))])])])
     ),
     case::not_constraint(
         load_anonymous_type(r#" // For a schema with not constraint as below:
                     { not: { type: int } }
                 "#),
-        IslType::anonymous([IslConstraint::not(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]))])
+        IslType::anonymous([v_1_0::not(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]))])
     ),
     case::ordered_elements_constraint(
         load_anonymous_type(r#" // For a schema with ordered_elements constraint as below:
-                    { ordered_elements: [  symbol, { type: int, occurs: optional },  ] }
+                    { ordered_elements: [  symbol, { type: int },  ] }
                 "#),
-        IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(Range::optional())])])])
+        IslType::anonymous([v_1_0::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])])])
     ),
     case::fields_constraint(
         load_anonymous_type(r#" // For a schema with fields constraint as below:
                     { fields: { name: string, id: int} }
                 "#),
-        IslType::anonymous([IslConstraint::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
+        IslType::anonymous([v_1_0::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
     ),
     case::contains_constraint(
         load_anonymous_type(r#" // For a schema with contains constraint as below:
                     { contains: [true, 1, "hello"] }
                 "#),
-        IslType::anonymous([IslConstraint::contains([true.into(), 1.into(), "hello".to_owned().into()])])
+        IslType::anonymous([v_1_0::contains([true.into(), 1.into(), "hello".to_owned().into()])])
     ),
     case::container_length_constraint(
         load_anonymous_type(r#" // For a schema with container_length constraint as below:
                     { container_length: 3 }
                 "#),
-        IslType::anonymous([IslConstraint::container_length(3.into())])
+        IslType::anonymous([v_1_0::container_length(3.into())])
     ),
     case::byte_length_constraint(
         load_anonymous_type(r#" // For a schema with byte_length constraint as below:
                     { byte_length: 3 }
                 "#),
-        IslType::anonymous([IslConstraint::byte_length(3.into())])
+        IslType::anonymous([v_1_0::byte_length(3.into())])
     ),
     case::codepoint_length_constraint(
         load_anonymous_type(r#" // For a schema with codepoint_length constraint as below:
                     { codepoint_length: 3 }
                 "#),
-        IslType::anonymous([IslConstraint::codepoint_length(3.into())])
+        IslType::anonymous([v_1_0::codepoint_length(3.into())])
     ),
     case::element_constraint(
         load_anonymous_type(r#" // For a schema with element constraint as below:
                     { element: int }
                 "#),
-        IslType::anonymous([IslConstraint::Element(IslTypeRef::named("int"))])
+        IslType::anonymous([v_1_0::element(IslTypeRef::named("int"))])
     ),
     case::annotations_constraint(
         load_anonymous_type(r#" // For a schema with annotations constraint as below:
                         { annotations: closed::[red, blue, green] }
                     "#),
-        IslType::anonymous([IslConstraint::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])])
+        IslType::anonymous([v_1_0::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])])
     ),
     case::precision_constraint(
         load_anonymous_type(r#" // For a schema with precision constraint as below:
                         { precision: 2 }
                     "#),
-        IslType::anonymous([IslConstraint::precision(2.into())])
+        IslType::anonymous([v_1_0::precision(2.into())])
     ),
     case::scale_constraint(
         load_anonymous_type(r#" // For a schema with scale constraint as below:
                         { scale: 2 }
                     "#),
-        IslType::anonymous([IslConstraint::scale(IntegerValue::I64(2).into())])
+        IslType::anonymous([v_1_0::scale(IntegerValue::I64(2).into())])
     ),
     case::timestamp_precision_constraint(
         load_anonymous_type(r#" // For a schema with timestamp_precision constraint as below:
                             { timestamp_precision: year }
                         "#),
-        IslType::anonymous([IslConstraint::timestamp_precision("year".try_into().unwrap())])
+        IslType::anonymous([v_1_0::timestamp_precision("year".try_into().unwrap())])
     ),
     case::valid_values_constraint(
         load_anonymous_type(r#" // For a schema with valid_values constraint as below:
                         { valid_values: [2, 3.5, 5e7, "hello", hi] }
                     "#),
-        IslType::anonymous([IslConstraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()])
+        IslType::anonymous([v_1_0::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()])
     ),
     case::valid_values_with_range_constraint(
         load_anonymous_type(r#" // For a schema with valid_values constraint as below:
                         { valid_values: range::[1, 5.5] }
                     "#),
         IslType::anonymous(
-            [IslConstraint::valid_values_with_range(
+            [v_1_0::valid_values_with_range(
                 NumberRange::new(
                     Number::from(&IntegerValue::I64(1)),
                     Number::from(&Decimal::new(55, -1))
@@ -478,14 +479,14 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with utf8_byte_length constraint as below:
                         { utf8_byte_length: 3 }
                     "#),
-        IslType::anonymous([IslConstraint::utf8_byte_length(3.into())])
+        IslType::anonymous([v_1_0::utf8_byte_length(3.into())])
     ),
     case::regex_constraint(
         load_anonymous_type(r#" // For a schema with regex constraint as below:
                             { regex: "[abc]" }
                         "#),
         IslType::anonymous(
-            [IslConstraint::regex(
+            [v_1_0::regex(
                 false, // case insensitive
                 false, // multiline
                 "[abc]".to_string()
@@ -498,7 +499,7 @@ mod isl_tests {
                             { timestamp_offset: ["+00:00"] }
                         "#),
         IslType::anonymous(
-        [IslConstraint::timestamp_offset(vec!["+00:00".try_into().unwrap()])]
+        [v_1_0::timestamp_offset(vec!["+00:00".try_into().unwrap()])]
     )
     )
     )]

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -249,7 +249,7 @@ mod isl_tests {
     use crate::isl::isl_range::TimestampRange;
     use crate::isl::isl_range::{Range, RangeBoundaryValue, RangeType};
     use crate::isl::isl_type::v_1_0::*;
-    use crate::isl::isl_type::{IslType, IslTypeImpl, IslTypeKind};
+    use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::v_1_0::*;
     use crate::isl::util::TimestampPrecision;
     use crate::isl::IonSchemaLanguageVersion;
@@ -266,42 +266,38 @@ mod isl_tests {
 
     // helper function to create NamedIslType for isl tests
     fn load_named_type(text: &str) -> IslType {
-        let kind = IslTypeKind::Named(
-            IslTypeImpl::from_owned_element(
-                IonSchemaLanguageVersion::V1_0,
-                &element_reader()
-                    .read_one(text.as_bytes())
-                    .expect("parsing failed unexpectedly"),
-                &mut vec![],
-            )
-            .unwrap(),
-        );
-        let constraints = kind
+        let type_def = IslTypeImpl::from_owned_element(
+            IonSchemaLanguageVersion::V1_0,
+            &element_reader()
+                .read_one(text.as_bytes())
+                .expect("parsing failed unexpectedly"),
+            &mut vec![],
+        )
+        .unwrap();
+        let constraints = type_def
             .constraints()
             .iter()
             .map(|c| IslConstraint::new(IonSchemaLanguageVersion::V1_0, c.to_owned()))
             .collect();
-        IslType::new(kind, constraints)
+        IslType::new(type_def, constraints)
     }
 
     // helper function to create AnonymousIslType for isl tests
     fn load_anonymous_type(text: &str) -> IslType {
-        let kind = IslTypeKind::Anonymous(
-            IslTypeImpl::from_owned_element(
-                IonSchemaLanguageVersion::V1_0,
-                &element_reader()
-                    .read_one(text.as_bytes())
-                    .expect("parsing failed unexpectedly"),
-                &mut vec![],
-            )
-            .unwrap(),
-        );
-        let constraints = kind
+        let type_def = IslTypeImpl::from_owned_element(
+            IonSchemaLanguageVersion::V1_0,
+            &element_reader()
+                .read_one(text.as_bytes())
+                .expect("parsing failed unexpectedly"),
+            &mut vec![],
+        )
+        .unwrap();
+        let constraints = type_def
             .constraints()
             .iter()
             .map(|c| IslConstraint::new(IonSchemaLanguageVersion::V1_0, c.to_owned()))
             .collect();
-        IslType::new(kind, constraints)
+        IslType::new(type_def, constraints)
     }
 
     #[test]

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -87,7 +87,7 @@ pub mod util;
 
 /// Represents Ion Schema Language Versions
 /// Currently it support v1.0 and v2.0
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum IonSchemaLanguageVersion {
     V1_0,
     V2_0,
@@ -241,6 +241,7 @@ impl IslSchemaV1_0 {
 #[cfg(test)]
 mod isl_tests {
     use crate::isl::isl_constraint::v_1_0::*;
+    use crate::isl::isl_constraint::IslConstraint;
     use crate::isl::isl_range::DecimalRange;
     use crate::isl::isl_range::FloatRange;
     use crate::isl::isl_range::IntegerRange;
@@ -267,7 +268,7 @@ mod isl_tests {
 
     // helper function to create NamedIslType for isl tests
     fn load_named_type(text: &str) -> IslType {
-        IslType::new(IslTypeKind::Named(
+        let kind = IslTypeKind::Named(
             IslTypeImpl::from_owned_element(
                 IonSchemaLanguageVersion::V1_0,
                 &element_reader()
@@ -276,12 +277,18 @@ mod isl_tests {
                 &mut vec![],
             )
             .unwrap(),
-        ))
+        );
+        let constraints = kind
+            .constraints()
+            .iter()
+            .map(|c| IslConstraint::new(IonSchemaLanguageVersion::V1_0, c.to_owned()))
+            .collect();
+        IslType::new(kind, constraints)
     }
 
     // helper function to create AnonymousIslType for isl tests
     fn load_anonymous_type(text: &str) -> IslType {
-        IslType::new(IslTypeKind::Anonymous(
+        let kind = IslTypeKind::Anonymous(
             IslTypeImpl::from_owned_element(
                 IonSchemaLanguageVersion::V1_0,
                 &element_reader()
@@ -290,7 +297,13 @@ mod isl_tests {
                 &mut vec![],
             )
             .unwrap(),
-        ))
+        );
+        let constraints = kind
+            .constraints()
+            .iter()
+            .map(|c| IslConstraint::new(IonSchemaLanguageVersion::V1_0, c.to_owned()))
+            .collect();
+        IslType::new(kind, constraints)
     }
 
     #[test]

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -83,9 +83,19 @@ pub mod isl_type;
 pub mod isl_type_reference;
 pub mod util;
 
+/// Represents Ion Schema Language Versions
+/// Currently it support v1.0 and v2.0
+#[derive(Debug, Clone)]
+pub enum IonSchemaLanguageVersion {
+    V10,
+    V20,
+}
+
 /// Provides an internal representation of an schema file
 #[derive(Debug, Clone)]
 pub struct IslSchema {
+    /// Represents Ion Schema Language version
+    isl_version: IonSchemaLanguageVersion,
     /// Represents all the IslImports inside the schema file.
     /// For more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#imports
     imports: Vec<IslImport>,
@@ -113,12 +123,14 @@ pub struct IslSchema {
 
 impl IslSchema {
     pub fn new(
+        isl_version: IonSchemaLanguageVersion,
         imports: Vec<IslImport>,
         types: Vec<IslType>,
         inline_imports: Vec<IslImportType>,
         open_content: Vec<Element>,
     ) -> Self {
         Self {
+            isl_version,
             imports,
             types,
             inline_imported_types: inline_imports,
@@ -126,6 +138,9 @@ impl IslSchema {
         }
     }
 
+    pub fn isl_version(&self) -> IonSchemaLanguageVersion {
+        self.isl_version.to_owned()
+    }
     pub fn imports(&self) -> &[IslImport] {
         &self.imports
     }
@@ -159,6 +174,7 @@ mod isl_tests {
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
     use crate::isl::util::TimestampPrecision;
+    use crate::isl::IonSchemaLanguageVersion;
     use crate::result::IonSchemaResult;
     use ion_rs::types::decimal::*;
     use ion_rs::types::integer::Integer as IntegerValue;
@@ -174,6 +190,7 @@ mod isl_tests {
     fn load_named_type(text: &str) -> IslType {
         IslType::Named(
             IslTypeImpl::from_owned_element(
+                IonSchemaLanguageVersion::V10,
                 &element_reader()
                     .read_one(text.as_bytes())
                     .expect("parsing failed unexpectedly"),
@@ -187,6 +204,7 @@ mod isl_tests {
     fn load_anonymous_type(text: &str) -> IslType {
         IslType::Anonymous(
             IslTypeImpl::from_owned_element(
+                IonSchemaLanguageVersion::V10,
                 &element_reader()
                     .read_one(text.as_bytes())
                     .expect("parsing failed unexpectedly"),

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -164,3 +164,10 @@ fn load(text: &str) -> Vec<Element> {
         .read_all(text.as_bytes())
         .expect("parsing failed unexpectedly")
 }
+
+#[derive(Debug, Clone, Default)]
+pub struct UserReservedFields {
+    schema_header_fields: Vec<String>,
+    schema_footer_fields: Vec<String>,
+    type_fields: Vec<String>,
+}

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -112,7 +112,7 @@ impl Iterator for SchemaTypeIterator {
 #[cfg(test)]
 mod schema_tests {
     use super::*;
-    use crate::isl::IonSchemaLanguageVersion;
+    use crate::isl::IslVersion;
     use crate::system::Resolver;
     use ion_rs::value::owned::Element;
     use ion_rs::value::reader::element_reader;
@@ -134,19 +134,11 @@ mod schema_tests {
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and create a schema from isl
-        let isl = resolver.isl_schema_from_elements(
-            IonSchemaLanguageVersion::V1_0,
-            owned_elements,
-            "my_schema.isl",
-        );
+        let isl =
+            resolver.isl_schema_from_elements(IslVersion::V1_0, owned_elements, "my_schema.isl");
 
         resolver
-            .schema_from_isl_schema(
-                IonSchemaLanguageVersion::V1_0,
-                isl.unwrap(),
-                type_store,
-                None,
-            )
+            .schema_from_isl_schema(IslVersion::V1_0, isl.unwrap(), type_store, None)
             .unwrap()
     }
 
@@ -313,20 +305,13 @@ mod schema_tests {
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and verifies if the result is `ok`
-        let isl = resolver.isl_schema_from_elements(
-            IonSchemaLanguageVersion::V1_0,
-            owned_elements,
-            "my_schema.isl",
-        );
+        let isl =
+            resolver.isl_schema_from_elements(IslVersion::V1_0, owned_elements, "my_schema.isl");
         assert!(isl.is_ok());
 
         // create a schema from isl and verifies if the result is `ok`
-        let schema = resolver.schema_from_isl_schema(
-            IonSchemaLanguageVersion::V1_0,
-            isl.unwrap(),
-            type_store,
-            None,
-        );
+        let schema =
+            resolver.schema_from_isl_schema(IslVersion::V1_0, isl.unwrap(), type_store, None);
         assert!(schema.is_ok());
 
         // check if the types of the created schema matches with the actual types specified by test case

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -133,10 +133,10 @@ mod schema_tests {
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and create a schema from isl
-        let isl = resolver.isl_schema_from_elements(owned_elements, "my_schema.isl");
+        let isl = resolver.isl_schema_v1_0_from_elements(owned_elements, "my_schema.isl");
 
         resolver
-            .schema_from_isl_schema(isl.unwrap(), "my_schema.isl", type_store, None)
+            .schema_from_isl_schema_v1_0(isl.unwrap(), "my_schema.isl", type_store, None)
             .unwrap()
     }
 
@@ -303,12 +303,12 @@ mod schema_tests {
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and verifies if the result is `ok`
-        let isl = resolver.isl_schema_from_elements(owned_elements, "my_schema.isl");
+        let isl = resolver.isl_schema_v1_0_from_elements(owned_elements, "my_schema.isl");
         assert!(isl.is_ok());
 
         // create a schema from isl and verifies if the result is `ok`
         let schema =
-            resolver.schema_from_isl_schema(isl.unwrap(), "my_schema.isl", type_store, None);
+            resolver.schema_from_isl_schema_v1_0(isl.unwrap(), "my_schema.isl", type_store, None);
         assert!(schema.is_ok());
 
         // check if the types of the created schema matches with the actual types specified by test case

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -136,7 +136,7 @@ mod schema_tests {
         let isl = resolver.isl_schema_v1_0_from_elements(owned_elements, "my_schema.isl");
 
         resolver
-            .schema_from_isl_schema_v1_0(isl.unwrap(), "my_schema.isl", type_store, None)
+            .schema_from_isl_schema_v1_0(isl.unwrap(), type_store, None)
             .unwrap()
     }
 
@@ -307,8 +307,7 @@ mod schema_tests {
         assert!(isl.is_ok());
 
         // create a schema from isl and verifies if the result is `ok`
-        let schema =
-            resolver.schema_from_isl_schema_v1_0(isl.unwrap(), "my_schema.isl", type_store, None);
+        let schema = resolver.schema_from_isl_schema_v1_0(isl.unwrap(), type_store, None);
         assert!(schema.is_ok());
 
         // check if the types of the created schema matches with the actual types specified by test case

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -112,6 +112,7 @@ impl Iterator for SchemaTypeIterator {
 #[cfg(test)]
 mod schema_tests {
     use super::*;
+    use crate::isl::IonSchemaLanguageVersion;
     use crate::system::Resolver;
     use ion_rs::value::owned::Element;
     use ion_rs::value::reader::element_reader;
@@ -133,10 +134,19 @@ mod schema_tests {
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and create a schema from isl
-        let isl = resolver.isl_schema_v1_0_from_elements(owned_elements, "my_schema.isl");
+        let isl = resolver.isl_schema_from_elements(
+            IonSchemaLanguageVersion::V1_0,
+            owned_elements,
+            "my_schema.isl",
+        );
 
         resolver
-            .schema_from_isl_schema_v1_0(isl.unwrap(), type_store, None)
+            .schema_from_isl_schema(
+                IonSchemaLanguageVersion::V1_0,
+                isl.unwrap(),
+                type_store,
+                None,
+            )
             .unwrap()
     }
 
@@ -303,11 +313,20 @@ mod schema_tests {
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and verifies if the result is `ok`
-        let isl = resolver.isl_schema_v1_0_from_elements(owned_elements, "my_schema.isl");
+        let isl = resolver.isl_schema_from_elements(
+            IonSchemaLanguageVersion::V1_0,
+            owned_elements,
+            "my_schema.isl",
+        );
         assert!(isl.is_ok());
 
         // create a schema from isl and verifies if the result is `ok`
-        let schema = resolver.schema_from_isl_schema_v1_0(isl.unwrap(), type_store, None);
+        let schema = resolver.schema_from_isl_schema(
+            IonSchemaLanguageVersion::V1_0,
+            isl.unwrap(),
+            type_store,
+            None,
+        );
         assert!(schema.is_ok());
 
         // check if the types of the created schema matches with the actual types specified by test case

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -21,7 +21,7 @@
 
 use crate::authority::DocumentAuthority;
 use crate::external::ion_rs::Symbol;
-use crate::isl::isl_constraint::IslConstraint;
+use crate::isl::isl_constraint::IslConstraintImpl;
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::{IslType, IslTypeImpl};
 use crate::isl::{IonSchemaLanguageVersion, IslSchemaV1_0, IslSchemaV2_0};
@@ -838,9 +838,9 @@ impl Resolver {
                 let unknown_fields: &Vec<&String> = &isl_type
                     .constraints()
                     .iter()
-                    .filter(|c| matches!(c, IslConstraint::Unknown(_, _)))
+                    .filter(|c| matches!(c, IslConstraintImpl::Unknown(_, _)))
                     .map(|c| match c {
-                        IslConstraint::Unknown(f, v) => f,
+                        IslConstraintImpl::Unknown(f, v) => f,
                         _ => {
                             unreachable!("we have already filtered all other constraints")
                         }

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -21,7 +21,7 @@
 
 use crate::authority::DocumentAuthority;
 use crate::external::ion_rs::Symbol;
-use crate::isl::isl_constraint::IslConstraintImpl;
+use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::{IslType, IslTypeImpl, IslTypeKind};
 use crate::isl::{IonSchemaLanguageVersion, IslSchemaV1_0, IslSchemaV2_0};
@@ -854,7 +854,12 @@ impl Resolver {
                     return invalid_schema_error("schema type contains unexpected fields");
                 }
 
-                isl_types.push(IslType::new(IslTypeKind::Named(isl_type)));
+                let constraints = isl_type
+                    .constraints()
+                    .iter()
+                    .map(|c| IslConstraint::new(IonSchemaLanguageVersion::V2_0, c.to_owned()))
+                    .collect();
+                isl_types.push(IslType::new(IslTypeKind::Named(isl_type), constraints));
             }
             // load footer for schema
             else if annotations.contains(&&text_token("schema_footer")) {
@@ -955,7 +960,12 @@ impl Resolver {
                         "Top level types must contain field `name` in their definition",
                     );
                 }
-                isl_types.push(IslType::new(IslTypeKind::Named(isl_type)));
+                let constraints = isl_type
+                    .constraints()
+                    .iter()
+                    .map(|c| IslConstraint::new(IonSchemaLanguageVersion::V1_0, c.to_owned()))
+                    .collect();
+                isl_types.push(IslType::new(IslTypeKind::Named(isl_type), constraints));
             }
             // load footer for schema
             else if annotations.contains(&&text_token("schema_footer")) {

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -806,7 +806,7 @@ mod type_definition_tests {
         let this_type_def = match isl_type {
             IslType::Named(named_isl_type) => {
                 let type_id = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
-                    IonSchemaLanguageVersion::V10,
+                    IonSchemaLanguageVersion::V1_0,
                     &named_isl_type,
                     type_store,
                     pending_types,
@@ -819,7 +819,7 @@ mod type_definition_tests {
             }
             IslType::Anonymous(anonymous_isl_type) => {
                 let type_id = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
-                    IonSchemaLanguageVersion::V10,
+                    IonSchemaLanguageVersion::V1_0,
                     &anonymous_isl_type,
                     type_store,
                     pending_types,

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -3,7 +3,7 @@ use crate::ion_path::IonPath;
 use crate::isl::isl_constraint::IslConstraintImpl;
 use crate::isl::isl_range::Range;
 use crate::isl::isl_type::IslTypeImpl;
-use crate::isl::IonSchemaLanguageVersion;
+use crate::isl::IslVersion;
 use crate::result::{IonSchemaResult, ValidationResult};
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::violation::{Violation, ViolationCode};
@@ -123,7 +123,7 @@ pub enum Nullability {
 
 impl BuiltInTypeDefinition {
     pub(crate) fn parse_from_isl_type(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         isl_type: &IslTypeImpl,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
@@ -137,7 +137,7 @@ impl BuiltInTypeDefinition {
         for isl_constraint in isl_type.constraints() {
             // For built in types, open_content is set as true as Ion Schema by default allows open content
             let constraint = Constraint::resolve_from_isl_constraint(
-                isl_version.to_owned(),
+                isl_version,
                 isl_constraint,
                 type_store,
                 pending_types,
@@ -414,7 +414,7 @@ impl TypeDefinitionImpl {
     ///
     /// [`IonSchemaError`]: crate::result::IonSchemaError
     pub(crate) fn parse_from_isl_type_and_update_pending_types(
-        isl_version: IonSchemaLanguageVersion,
+        isl_version: IslVersion,
         isl_type: &IslTypeImpl,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
@@ -440,7 +440,7 @@ impl TypeDefinitionImpl {
             }
 
             let constraint = Constraint::resolve_from_isl_constraint(
-                isl_version.to_owned(),
+                isl_version,
                 isl_constraint,
                 type_store,
                 pending_types,
@@ -462,7 +462,7 @@ impl TypeDefinitionImpl {
             };
 
             let isl_constraint = IslConstraintImpl::from_ion_element(
-                isl_version.to_owned(),
+                isl_version,
                 "type",
                 &Element::new_symbol(text_token("any")),
                 &isl_type_name,
@@ -806,7 +806,7 @@ mod type_definition_tests {
         let pending_types = &mut PendingTypes::default();
         let this_type_def = {
             let type_id = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
-                IonSchemaLanguageVersion::V1_0,
+                IslVersion::V1_0,
                 &isl_type.type_definition,
                 type_store,
                 pending_types,

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -3,6 +3,7 @@ use crate::ion_path::IonPath;
 use crate::isl::isl_constraint::IslConstraint;
 use crate::isl::isl_range::Range;
 use crate::isl::isl_type::IslTypeImpl;
+use crate::isl::IonSchemaLanguageVersion;
 use crate::result::{IonSchemaResult, ValidationResult};
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::violation::{Violation, ViolationCode};
@@ -122,6 +123,7 @@ pub enum Nullability {
 
 impl BuiltInTypeDefinition {
     pub fn parse_from_isl_type(
+        isl_version: IonSchemaLanguageVersion,
         isl_type: &IslTypeImpl,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
@@ -135,6 +137,7 @@ impl BuiltInTypeDefinition {
         for isl_constraint in isl_type.constraints() {
             // For built in types, open_content is set as true as Ion Schema by default allows open content
             let constraint = Constraint::resolve_from_isl_constraint(
+                isl_version.to_owned(),
                 isl_constraint,
                 type_store,
                 pending_types,
@@ -411,6 +414,7 @@ impl TypeDefinitionImpl {
     ///
     /// [`IonSchemaError`]: crate::result::IonSchemaError
     pub fn parse_from_isl_type_and_update_pending_types(
+        isl_version: IonSchemaLanguageVersion,
         isl_type: &IslTypeImpl,
         type_store: &mut TypeStore,
         pending_types: &mut PendingTypes,
@@ -436,6 +440,7 @@ impl TypeDefinitionImpl {
             }
 
             let constraint = Constraint::resolve_from_isl_constraint(
+                isl_version.to_owned(),
                 isl_constraint,
                 type_store,
                 pending_types,
@@ -457,12 +462,14 @@ impl TypeDefinitionImpl {
             };
 
             let isl_constraint = IslConstraint::from_ion_element(
+                isl_version.to_owned(),
                 "type",
                 &Element::new_symbol(text_token("any")),
                 &isl_type_name,
                 &mut vec![],
             )?;
             let constraint = Constraint::resolve_from_isl_constraint(
+                isl_version,
                 &isl_constraint,
                 type_store,
                 pending_types,
@@ -799,6 +806,7 @@ mod type_definition_tests {
         let this_type_def = match isl_type {
             IslType::Named(named_isl_type) => {
                 let type_id = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
+                    IonSchemaLanguageVersion::V10,
                     &named_isl_type,
                     type_store,
                     pending_types,
@@ -811,6 +819,7 @@ mod type_definition_tests {
             }
             IslType::Anonymous(anonymous_isl_type) => {
                 let type_id = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
+                    IonSchemaLanguageVersion::V10,
                     &anonymous_isl_type,
                     type_store,
                     pending_types,

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -575,7 +575,7 @@ mod type_definition_tests {
     use crate::isl::isl_range::Number;
     use crate::isl::isl_range::NumberRange;
     use crate::isl::isl_type::v_1_0::*;
-    use crate::isl::isl_type::{IslType, IslTypeKind};
+    use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::v_1_0::*;
     use crate::system::PendingTypes;
     use ion_rs::Decimal;
@@ -804,33 +804,18 @@ mod type_definition_tests {
         // assert if both the TypeDefinition are same in terms of constraints and name
         let type_store = &mut TypeStore::default();
         let pending_types = &mut PendingTypes::default();
-        let this_type_def = match isl_type.kind {
-            IslTypeKind::Named(named_isl_type) => {
-                let type_id = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
-                    IonSchemaLanguageVersion::V1_0,
-                    &named_isl_type,
-                    type_store,
-                    pending_types,
-                )
+        let this_type_def = {
+            let type_id = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
+                IonSchemaLanguageVersion::V1_0,
+                &isl_type.type_definition,
+                type_store,
+                pending_types,
+            )
+            .unwrap();
+            pending_types
+                .update_type_store(type_store, None, &HashSet::new())
                 .unwrap();
-                pending_types
-                    .update_type_store(type_store, None, &HashSet::new())
-                    .unwrap();
-                type_store.get_type_by_id(type_id).unwrap()
-            }
-            IslTypeKind::Anonymous(anonymous_isl_type) => {
-                let type_id = TypeDefinitionImpl::parse_from_isl_type_and_update_pending_types(
-                    IonSchemaLanguageVersion::V1_0,
-                    &anonymous_isl_type,
-                    type_store,
-                    pending_types,
-                )
-                .unwrap();
-                pending_types
-                    .update_type_store(type_store, None, &HashSet::new())
-                    .unwrap();
-                type_store.get_type_by_id(type_id).unwrap()
-            }
+            type_store.get_type_by_id(type_id).unwrap()
         };
         assert_eq!(this_type_def, &type_def);
     }

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -1,6 +1,6 @@
 use crate::constraint::Constraint;
 use crate::ion_path::IonPath;
-use crate::isl::isl_constraint::IslConstraint;
+use crate::isl::isl_constraint::IslConstraintImpl;
 use crate::isl::isl_range::Range;
 use crate::isl::isl_type::IslTypeImpl;
 use crate::isl::IonSchemaLanguageVersion;
@@ -435,7 +435,7 @@ impl TypeDefinitionImpl {
         // convert IslConstraint to Constraint
         let mut found_type_constraint = false;
         for isl_constraint in isl_type.constraints() {
-            if let IslConstraint::Type(_) = isl_constraint {
+            if let IslConstraintImpl::Type(_) = isl_constraint {
                 found_type_constraint = true;
             }
 
@@ -461,7 +461,7 @@ impl TypeDefinitionImpl {
                 },
             };
 
-            let isl_constraint = IslConstraint::from_ion_element(
+            let isl_constraint = IslConstraintImpl::from_ion_element(
                 isl_version.to_owned(),
                 "type",
                 &Element::new_symbol(text_token("any")),
@@ -571,7 +571,7 @@ impl Display for TypeDefinitionImpl {
 mod type_definition_tests {
     use super::*;
     use crate::constraint::Constraint;
-    use crate::isl::isl_constraint::IslConstraint;
+    use crate::isl::isl_constraint::v_1_0;
     use crate::isl::isl_range::Number;
     use crate::isl::isl_range::NumberRange;
     use crate::isl::isl_type::IslType;
@@ -589,154 +589,154 @@ mod type_definition_tests {
         /* For a schema with single anonymous type as below:
             { type: int }
          */
-        IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]),
+        IslType::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]),
         TypeDefinition::anonymous([Constraint::type_constraint(0)])
     ),
     case::type_constraint_with_named_type(
         /* For a schema with named type as below:
             { name: my_int, type: int }
          */
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::named("int"))]),
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::named("int"))]),
         TypeDefinition::named("my_int", [Constraint::type_constraint(0)])
     ),
     case::type_constraint_with_self_reference_type(
         /* For a schema with self reference type as below:
             { name: my_int, type: my_int }
          */
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::named("my_int"))]),
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::named("my_int"))]),
         TypeDefinition::named("my_int", [Constraint::type_constraint(35)])
     ),
     case::type_constraint_with_nested_self_reference_type(
         /* For a schema with nested self reference type as below:
             { name: my_int, type: { type: my_int } }
          */
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("my_int"))]))]),
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("my_int"))]))]),
         TypeDefinition::named("my_int", [Constraint::type_constraint(36)]) // 0-35 are built-in types which are preloaded to the type_store
     ),
     case::type_constraint_with_nested_type(
         /* For a schema with nested types as below:
             { name: my_int, type: { type: int } }
          */
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]))]),
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]))]),
         TypeDefinition::named("my_int", [Constraint::type_constraint(36)])
     ),
     case::type_constraint_with_nested_multiple_types(
         /* For a schema with nested multiple types as below:
             { name: my_int, type: { type: int }, type: { type: my_int } }
          */
-        IslType::named("my_int", [IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))])), IslConstraint::type_constraint(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("my_int"))]))]),
+        IslType::named("my_int", [v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])), v_1_0::type_constraint(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("my_int"))]))]),
         TypeDefinition::named("my_int", [Constraint::type_constraint(36), Constraint::type_constraint(37)])
     ),
     case::all_of_constraint(
         /* For a schema with all_of type as below:
             { all_of: [{ type: int }] }
         */
-        IslType::anonymous([IslConstraint::all_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))])])]),
+        IslType::anonymous([v_1_0::all_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])])]),
         TypeDefinition::anonymous([Constraint::all_of([36]), Constraint::type_constraint(34)])
     ),
     case::any_of_constraint(
         /* For a schema with any_of constraint as below:
             { any_of: [{ type: int }, { type: decimal }] }
         */
-        IslType::anonymous([IslConstraint::any_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("decimal"))])])]),
+        IslType::anonymous([v_1_0::any_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("decimal"))])])]),
         TypeDefinition::anonymous([Constraint::any_of([36, 37]), Constraint::type_constraint(34)])
     ),
     case::one_of_constraint(
         /* For a schema with one_of constraint as below:
             { any_of: [{ type: int }, { type: decimal }] }
         */
-        IslType::anonymous([IslConstraint::one_of([IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("decimal"))])])]),
+        IslType::anonymous([v_1_0::one_of([IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("decimal"))])])]),
         TypeDefinition::anonymous([Constraint::one_of([36, 37]), Constraint::type_constraint(34)])
     ),
     case::not_constraint(
         /* For a schema with not constraint as below:
             { not: { type: int } }
         */
-        IslType::anonymous([IslConstraint::not(IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]))]),
+        IslType::anonymous([v_1_0::not(IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]))]),
         TypeDefinition::anonymous([Constraint::not(36), Constraint::type_constraint(34)])
     ),
     case::ordered_elements_constraint(
         /* For a schema with ordered_elements constraint as below:
-            { ordered_elements: [ symbol, { type: int, occurs: optional }, ] }
+            { ordered_elements: [ symbol, { type: int }, ] }
         */
-        IslType::anonymous([IslConstraint::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int")), IslConstraint::Occurs(Range::optional())])])]),
+        IslType::anonymous([v_1_0::ordered_elements([IslTypeRef::named("symbol"), IslTypeRef::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))])])]),
         TypeDefinition::anonymous([Constraint::ordered_elements([5, 36]), Constraint::type_constraint(34)])
     ),
     case::fields_constraint(
         /* For a schema with fields constraint as below:
             { fields: { name: string, id: int} }
         */
-        IslType::anonymous([IslConstraint::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
+        IslType::anonymous([v_1_0::fields(vec![("name".to_owned(), IslTypeRef::named("string")), ("id".to_owned(), IslTypeRef::named("int"))].into_iter())]),
         TypeDefinition::anonymous([Constraint::fields(vec![("name".to_owned(), 4), ("id".to_owned(), 0)].into_iter()), Constraint::type_constraint(34)])
     ),
     case::contains_constraint(
         /* For a schema with contains constraint as below:
             { contains: [true, 1, "hello"] }
         */
-        IslType::anonymous([IslConstraint::contains([true.into(), 1.into(), "hello".to_owned().into()])]),
+        IslType::anonymous([v_1_0::contains([true.into(), 1.into(), "hello".to_owned().into()])]),
         TypeDefinition::anonymous([Constraint::contains([true.into(), 1.into(), "hello".to_owned().into()]), Constraint::type_constraint(34)])
         ),
     case::container_length_constraint(
         /* For a schema with container_length constraint as below:
             { container_length: 3 }
         */
-        IslType::anonymous([IslConstraint::container_length(3.into())]),
+        IslType::anonymous([v_1_0::container_length(3.into())]),
         TypeDefinition::anonymous([Constraint::container_length(3.into()), Constraint::type_constraint(34)])
     ),
     case::byte_length_constraint(
         /* For a schema with byte_length constraint as below:
             { byte_length: 3 }
         */
-        IslType::anonymous([IslConstraint::byte_length(3.into())]),
+        IslType::anonymous([v_1_0::byte_length(3.into())]),
         TypeDefinition::anonymous([Constraint::byte_length(3.into()), Constraint::type_constraint(34)])
     ),
     case::codepoint_length_constraint(
         /* For a schema with codepoint_length constraint as below:
             { codepoint_length: 3 }
         */
-        IslType::anonymous([IslConstraint::codepoint_length(3.into())]),
+        IslType::anonymous([v_1_0::codepoint_length(3.into())]),
         TypeDefinition::anonymous([Constraint::codepoint_length(3.into()), Constraint::type_constraint(34)])
     ),
     case::element_constraint(
         /* For a schema with element constraint as below:
             { element: int }
         */
-        IslType::anonymous([IslConstraint::element(IslTypeRef::named("int"))]),
+        IslType::anonymous([v_1_0::element(IslTypeRef::named("int"))]),
         TypeDefinition::anonymous([Constraint::element(0), Constraint::type_constraint(34)])
     ),
     case::annotations_constraint(
         /* For a schema with annotations constraint as below:
             { annotations: closed::[red, blue, green] }
         */
-        IslType::anonymous([IslConstraint::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])]),
+        IslType::anonymous([v_1_0::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])]),
         TypeDefinition::anonymous([Constraint::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()]), Constraint::type_constraint(34)])
     ),
     case::precision_constraint(
         /* For a schema with precision constraint as below:
             { precision: 3 }
         */
-        IslType::anonymous([IslConstraint::precision(3.into())]),
+        IslType::anonymous([v_1_0::precision(3.into())]),
         TypeDefinition::anonymous([Constraint::precision(3.into()), Constraint::type_constraint(34)])
     ),
     case::scale_constraint(
         /* For a schema with scale constraint as below:
             { scale: 2 }
         */
-        IslType::anonymous([IslConstraint::scale(Integer::I64(2).into())]),
+        IslType::anonymous([v_1_0::scale(Integer::I64(2).into())]),
         TypeDefinition::anonymous([Constraint::scale(Integer::I64(2).into()), Constraint::type_constraint(34)])
     ),
     case::timestamp_precision_constraint(
         /* For a schema with timestamp_precision constraint as below:
             { timestamp_precision: month }
         */
-        IslType::anonymous([IslConstraint::timestamp_precision("month".try_into().unwrap())]),
+        IslType::anonymous([v_1_0::timestamp_precision("month".try_into().unwrap())]),
         TypeDefinition::anonymous([Constraint::timestamp_precision("month".try_into().unwrap()), Constraint::type_constraint(34)])
     ),
     case::valid_values_constraint(
         /* For a schema with valid_values constraint as below:
             { valid_values: [2, 3.5, 5e7, "hello", hi] }
         */
-        IslType::anonymous([IslConstraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()]),
+        IslType::anonymous([v_1_0::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()]),
         TypeDefinition::anonymous([Constraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap(), Constraint::type_constraint(34)])
     ),
     case::valid_values_with_range_constraint(
@@ -744,7 +744,7 @@ mod type_definition_tests {
             { valid_values: range::[1, 5.5] }
         */
         IslType::anonymous(
-            [IslConstraint::valid_values_with_range(
+            [v_1_0::valid_values_with_range(
                 NumberRange::new(
                     Number::from(&Integer::I64(1)),
                     Number::from(&Decimal::new(55, -1))
@@ -764,7 +764,7 @@ mod type_definition_tests {
         /* For a schema with utf8_byte_length constraint as below:
             { utf8_byte_length: 3 }
         */
-        IslType::anonymous([IslConstraint::utf8_byte_length(3.into())]),
+        IslType::anonymous([v_1_0::utf8_byte_length(3.into())]),
         TypeDefinition::anonymous([Constraint::utf8_byte_length(3.into()), Constraint::type_constraint(34)])
     ),
     case::regex_constraint(
@@ -772,7 +772,7 @@ mod type_definition_tests {
             { regex: "[abc]" }
         */
         IslType::anonymous(
-            [IslConstraint::regex(
+            [v_1_0::regex(
                 false, // case insensitive
                 false, // multiline
                 "[abc]".to_string()
@@ -792,7 +792,7 @@ mod type_definition_tests {
             { timestamp_offset: ["-00:00"] }
         */
         IslType::anonymous(
-            [IslConstraint::timestamp_offset(vec!["-00:00".try_into().unwrap()])]
+            [v_1_0::timestamp_offset(vec!["-00:00".try_into().unwrap()])]
         ),
         TypeDefinition::anonymous([Constraint::timestamp_offset(vec!["-00:00".try_into().unwrap()]),
             Constraint::type_constraint(34)

--- a/ion-schema/tests/reexport_external.rs
+++ b/ion-schema/tests/reexport_external.rs
@@ -21,7 +21,7 @@ mod reexport_tests {
     fn load_anonymous_type(text: &str) -> IslType {
         IslType::Anonymous(
             IslTypeImpl::from_owned_element(
-                IonSchemaLanguageVersion::V10,
+                IonSchemaLanguageVersion::V1_0,
                 &element_reader()
                     .read_one(text.as_bytes())
                     .expect("parsing failed unexpectedly"),

--- a/ion-schema/tests/reexport_external.rs
+++ b/ion-schema/tests/reexport_external.rs
@@ -1,33 +1,39 @@
 #[cfg(test)]
 mod reexport_tests {
-    use ion_schema::external::ion_rs::value::reader::{element_reader, ElementReader};
-    use ion_schema::isl::isl_constraint::v_1_0;
-    use ion_schema::isl::isl_type::{IslType, IslTypeImpl};
-    use ion_schema::isl::isl_type_reference::IslTypeRef;
-    use ion_schema::isl::IonSchemaLanguageVersion;
+    use ion_schema::authority::MapDocumentAuthority;
+    use ion_schema::isl::isl_constraint::v_1_0::*;
+    use ion_schema::isl::isl_type::v_1_0::*;
+    use ion_schema::isl::isl_type::IslType;
+    use ion_schema::isl::isl_type_reference::v_1_0::*;
+    use ion_schema::result::IonSchemaResult;
+    use ion_schema::system::SchemaSystem;
 
     /// This test shows how the ion_schema integration with ion_rs can be used
     /// through a reexport. This means that consumers of ion_schema can use this
     /// integration without having to specify the exact dependency version.
     #[test]
-    fn ion_rs_is_reexported() {
-        let actual_isl_type = load_anonymous_type("{type: int}");
-        let expected_isl_type =
-            IslType::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]);
-        assert_eq!(actual_isl_type, expected_isl_type);
-    }
+    fn ion_rs_is_reexported() -> IonSchemaResult<()> {
+        // map with (id, ion content)
+        let map_authority = [(
+            "sample.isl",
+            r#"
+                schema_header::{}
+                
+                type::{
+                  name: my_type,
+                  type: int,
+                }
+                
+                schema_footer::{}
+            "#,
+        )];
+        let mut schema_system =
+            SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
+        let schema = schema_system.load_isl_schema_v1_0("sample.isl")?;
+        let actual_isl_type: &IslType = &schema.types()[0];
 
-    // helper function to create anonymous ISL type
-    fn load_anonymous_type(text: &str) -> IslType {
-        IslType::Anonymous(
-            IslTypeImpl::from_owned_element(
-                IonSchemaLanguageVersion::V1_0,
-                &element_reader()
-                    .read_one(text.as_bytes())
-                    .expect("parsing failed unexpectedly"),
-                &mut vec![],
-            )
-            .unwrap(),
-        )
+        let expected_isl_type = &named_type("my_type", [type_constraint(named_type_ref("int"))]);
+        assert_eq!(actual_isl_type, expected_isl_type);
+        Ok(())
     }
 }

--- a/ion-schema/tests/reexport_external.rs
+++ b/ion-schema/tests/reexport_external.rs
@@ -29,7 +29,7 @@ mod reexport_tests {
         )];
         let mut schema_system =
             SchemaSystem::new(vec![Box::new(MapDocumentAuthority::new(map_authority))]);
-        let schema = schema_system.load_isl_schema_v1_0("sample.isl")?;
+        let schema = schema_system.load_isl_schema("sample.isl")?;
         let actual_isl_type: &IslType = &schema.types()[0];
 
         let expected_isl_type = &named_type("my_type", [type_constraint(named_type_ref("int"))]);

--- a/ion-schema/tests/reexport_external.rs
+++ b/ion-schema/tests/reexport_external.rs
@@ -4,6 +4,7 @@ mod reexport_tests {
     use ion_schema::isl::isl_constraint::IslConstraint;
     use ion_schema::isl::isl_type::{IslType, IslTypeImpl};
     use ion_schema::isl::isl_type_reference::IslTypeRef;
+    use ion_schema::isl::IonSchemaLanguageVersion;
 
     /// This test shows how the ion_schema integration with ion_rs can be used
     /// through a reexport. This means that consumers of ion_schema can use this
@@ -20,6 +21,7 @@ mod reexport_tests {
     fn load_anonymous_type(text: &str) -> IslType {
         IslType::Anonymous(
             IslTypeImpl::from_owned_element(
+                IonSchemaLanguageVersion::V10,
                 &element_reader()
                     .read_one(text.as_bytes())
                     .expect("parsing failed unexpectedly"),

--- a/ion-schema/tests/reexport_external.rs
+++ b/ion-schema/tests/reexport_external.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod reexport_tests {
     use ion_schema::external::ion_rs::value::reader::{element_reader, ElementReader};
-    use ion_schema::isl::isl_constraint::IslConstraint;
+    use ion_schema::isl::isl_constraint::v_1_0;
     use ion_schema::isl::isl_type::{IslType, IslTypeImpl};
     use ion_schema::isl::isl_type_reference::IslTypeRef;
     use ion_schema::isl::IonSchemaLanguageVersion;
@@ -13,7 +13,7 @@ mod reexport_tests {
     fn ion_rs_is_reexported() {
         let actual_isl_type = load_anonymous_type("{type: int}");
         let expected_isl_type =
-            IslType::anonymous([IslConstraint::type_constraint(IslTypeRef::named("int"))]);
+            IslType::anonymous([v_1_0::type_constraint(IslTypeRef::named("int"))]);
         assert_eq!(actual_isl_type, expected_isl_type);
     }
 


### PR DESCRIPTION
### Description of changes:
This PR works on adding version configuration changes to allow ISL 2.0 support.

### List of changes:
- fixes an issue with range construction which had a missing type check for range construction (95e97c973dfa06083227bfabda4813cceddaaefe)
- adds schema versioning configuration for all internal methods that were used to load schema or ISL model using an enum `IonSchemaLanguageVersion`(529fa2d02425d65bbda3062cda87ae0b5756c89e)
- `isl_type`, `isl_type_reference` and `isl_constraint` contains two modules with specific implementation of types/type references and constraints based on ISL version(`v_1_0` and `v_2_0`). This will help with easier API modifications with new major/minor version release.
- All the previously defined schema model structs/enums are now hidden inside wrapper classes which helps with hiding implementation details based on ISL versioning.
  -  e.g. `IslType` which was previously used to model an ISL type definition is now renamed as `IslTypeKind`. `IslTypeKind` has all the implementation details required to support both/all ISL version with a single struct. A new wrapper class that takes in this `IslTypeKind` to hide its implementation details. Along with that now `IslTypeKind` will be private to crate and users can only construct for `IslType` and use its accessor methods. In conclusion, all the wrapper classes are added to separate out implementation details  from public facing APIs/structs.
  - Similar to `IslType` following structures are changed to add on a layer of abstraction from implementation layer.
    -  `IslConstraint` enum has now changed to be called `IslConstraintImpl`. A wrapper class `IslCosntraint` is added on top of it that takes `IslConstraintImpl` to create the abstraction layer. 
    - Similarly `IslTypeRef` is now called `IslTypeRefImpl`. And it has wrapper class that is called `IslTypeRef`.
- added `UserReservedFields` struct that stores user reserved fields for ISL 2.0. 
- added validation for user reserved fields for ISL 2.0. 
- adds methods to `schema_system` that converts ISL model to a resolved schema called `schema_from_isl_schema`. 
   - `schema_from_isl_schema` makes sure that the given ISL model types contains the same version of ISL for their cosntraints. This check is not done while constructing the ISL model.
   - `v_1_0` and `v_2_0` modules does give user an idea on which ISL version they are using to construct the model but it does not guarantee that the model that is created has all the constraints from same version of ISL.  
- `IslSchema` now has two methods to construct schema for a particular version `schema_v_1_0` and `schema_v_2_0`.

### Example construction of ISL model programmatically using the new signature:
Using a single ISL type to construct ISL schema model as below:
```rust
// an ISL 1.0 type that contains ISL 1.0 related constraints
let isl_type = isl_type::v_1_0::named_type(
    "my_type",
    [isl_constraint::v_1_0::element(
        isl_type_reference::v_1_0::named_type_ref("int"),
    )],
);
let isl = IslSchema::schema_v_1_0("sample.isl", vec![], vec![isl_type], vec![], vec![]);
```

_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
