### PR TITLE
adds changes for making `SchemaSystem` Send and Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ use ion_schema::types::TypeRef;
 use ion_schema::IonSchemaElement;
 use std::fmt::Debug;
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 
 fn main() -> IonSchemaResult<()> {
     // Create authorities vector containing all the authorities that will be used to load a schema based on schema id
@@ -57,7 +57,7 @@ fn main() -> IonSchemaResult<()> {
     let schema_id = "my_schema.isl";
 
     // Load schema
-    let schema: Rc<Schema> = schema_system.load_schema(schema_id)?;
+    let schema: Arc<Schema> = schema_system.load_schema(schema_id)?;
 
     // Retrieve a particular type from this schema
     let type_ref: TypeRef = schema.get_type("my_int_type").unwrap();

--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.16.0"
+ion-rs = "0.17.0"
 ion-schema = { path = "../ion-schema" }
 quote = "1.0.21"
 syn = "1.0.102"

--- a/ion-schema-tests-runner/src/generator.rs
+++ b/ion-schema-tests-runner/src/generator.rs
@@ -127,7 +127,7 @@ fn generate_test_cases_for_file(ctx: Context) -> TokenStream {
     let isl_version = find_isl_version(&schema_content);
 
     for element in schema_content {
-        if element.has_annotation("$test") {
+        if element.annotations().contains("$test") {
             let test_cases: TestCaseVec = element
                 .try_into()
                 .unwrap_or_else(|e| panic!("Error in {path_string} - {e}"));
@@ -180,7 +180,8 @@ fn find_isl_version(schema_content: &[Element]) -> IslVersion {
     for value in schema_content {
         // if find a type definition or a schema header before finding any version marker then this is ISL 1.0
         if value.ion_type() == IonType::Struct
-            && (value.has_annotation("type") || value.has_annotation("schema_header"))
+            && (value.annotations().contains("type")
+                || value.annotations().contains("schema_header"))
         {
             // default ISL 1.0 version will be returned
             break;
@@ -265,7 +266,7 @@ fn generate_preamble(root_dir_path: &Path) -> TokenStream {
     let root_dir_token = TokenTree::from(Literal::string(root_dir_path.to_str().unwrap()));
 
     quote! {
-        use ion_rs::element::{IonSequence};
+        use ion_rs::element::Sequence;
         use std::hash::{Hash, Hasher};
 
         /// Gets the root directory for the test suite.
@@ -322,7 +323,7 @@ fn generate_preamble(root_dir_path: &Path) -> TokenStream {
             let schema = __new_schema_system().load_schema(schema_id).unwrap();
             let isl_type = schema.get_type(type_id).unwrap();
             let value: ion_rs::element::Element = ion_rs::element::Element::read_one(value_ion.as_bytes()).unwrap();
-            let prepared_value: ion_schema::IonSchemaElement = if value.has_annotation("document") && value.ion_type() == ion_rs::IonType::SExp {
+            let prepared_value: ion_schema::IonSchemaElement = if value.annotations().contains("document") && value.ion_type() == ion_rs::IonType::SExp {
                 let element_vec = value.as_sequence()
                     .unwrap_or_else(|| unreachable!("We already confirmed that this is a s-expression."))
                     .elements()

--- a/ion-schema-tests-runner/src/model.rs
+++ b/ion-schema-tests-runner/src/model.rs
@@ -1,4 +1,4 @@
-use ion_rs::element::{Element, IonSequence, List, Struct};
+use ion_rs::element::{Element, List, Struct};
 use std::ops::Deref;
 
 // Represents a single test case.
@@ -206,14 +206,14 @@ impl StructUtils for Struct {
                 Element::from(self.clone())
             ))
         } else if let Some(field) = self.get(field_name) {
-            let list = field.as_list().ok_or(format!(
+            let list = field.as_sequence().ok_or(format!(
                 "Malformed test case - field '{}' must be a list: {}",
                 field_name,
                 Element::from(self.clone())
             ))?;
-            Ok(list.clone())
+            Ok(ion_rs::element::List(list.clone()))
         } else {
-            Ok(Element::list_builder().build())
+            Ok(ion_rs::element::List(Element::sequence_builder().build()))
         }
     }
 }

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.16.0"
+ion-rs = "0.17.0"
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/ion-schema/src/authority.rs
+++ b/ion-schema/src/authority.rs
@@ -72,7 +72,12 @@ use std::path::{Path, PathBuf};
 ///
 /// The structure of a schema identifier string is defined by the
 /// Authority responsible for the schema/type(s) being imported.
-pub trait DocumentAuthority: Debug {
+///
+/// [`DocumentAuthority`] is *[Send and Sync]* i.e. it is safe to send it to another thread and to be shared between threads.
+/// For cases when one does need thread-safe interior mutability, they can use the explicit locking via [`std::sync::Mutex`] and [`std::sync::RwLock`].
+///
+/// [Send and Sync]: https://doc.rust-lang.org/nomicon/send-and-sync.html
+pub trait DocumentAuthority: Debug + Send + Sync {
     fn elements(&self, id: &str) -> IonSchemaResult<Vec<Element>>;
 }
 

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -1537,6 +1537,7 @@ impl AnnotationsConstraint {
     ) -> ValidationResult {
         let mut value_annotations = value
             .annotations()
+            .iter()
             .map(|sym| sym.text().unwrap())
             .peekable();
 
@@ -1598,15 +1599,16 @@ impl AnnotationsConstraint {
         // This will be used by a violation to to return all the missing annotations
         let mut missing_annotations: Vec<&Annotation> = vec![];
 
-        let value_annotations: Vec<&str> =
-            value.annotations().map(|sym| sym.text().unwrap()).collect();
+        let value_annotations: Vec<&str> = value
+            .annotations()
+            .iter()
+            .map(|sym| sym.text().unwrap())
+            .collect();
 
         for expected_annotation in &self.annotations {
             // verify if the expected_annotation is required and if it matches with value annotation
             if expected_annotation.is_required()
-                && !value
-                    .annotations()
-                    .any(|a| a.text().unwrap() == expected_annotation.value())
+                && !value.annotations().contains(expected_annotation.value())
             {
                 missing_annotations.push(expected_annotation);
             }

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -21,8 +21,8 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
 use std::iter::Peekable;
-use std::rc::Rc;
 use std::str::Chars;
+use std::sync::Arc;
 
 /// Provides validation for schema Constraint
 pub trait ConstraintValidator {
@@ -789,7 +789,7 @@ impl OrderedElementsConstraint {
             }
         }
 
-        NfaEvaluation::new(Rc::new(nfa_builder.build(final_states)))
+        NfaEvaluation::new(Arc::new(nfa_builder.build(final_states)))
     }
 }
 

--- a/ion-schema/src/ion_path.rs
+++ b/ion-schema/src/ion_path.rs
@@ -1,4 +1,4 @@
-use ion_rs::element::Element;
+use ion_rs::element::{Element, SExp, Sequence};
 use ion_rs::Symbol;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
@@ -74,15 +74,15 @@ impl IonPath {
 
 impl From<IonPath> for Element {
     fn from(value: IonPath) -> Element {
-        let mut ion_path = Element::sexp_builder();
+        let mut ion_path_elements = vec![];
         for parent in &value.ion_path_elements {
             let element = match parent {
                 IonPathElement::Index(index) => Element::from(*index as i64),
                 IonPathElement::Field(name) => Element::from(Symbol::from(name.as_str())),
             };
-            ion_path = ion_path.push(element);
+            ion_path_elements.push(element);
         }
-        ion_path.build().into()
+        SExp::from(Sequence::new(ion_path_elements)).into()
     }
 }
 

--- a/ion-schema/src/isl/isl_range.rs
+++ b/ion-schema/src/isl/isl_range.rs
@@ -3,11 +3,11 @@ use crate::isl::util::TimestampPrecision;
 use crate::result::{
     invalid_schema_error, invalid_schema_error_raw, IonSchemaError, IonSchemaResult,
 };
-use ion_rs::element::{Element, IonSequence};
+use ion_rs::element::Element;
 use ion_rs::external::bigdecimal::num_bigint::BigInt;
 use ion_rs::external::bigdecimal::{BigDecimal, One};
 use ion_rs::types::integer::IntAccess;
-use ion_rs::{Decimal, Int, IonType, Symbol, Timestamp};
+use ion_rs::{element, Decimal, Int, IonType, Timestamp};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::prelude::rust_2021::TryInto;
@@ -219,9 +219,9 @@ impl Range {
                     value.ion_type()
                 ))
             }
-        } else if let Some(range) = value.as_list() {
+        } else if let element::Value::List(range) = value.value() {
             // verify if the value has annotation range
-            if !value.annotations().any(|a| a == &Symbol::from("range")) {
+            if !value.annotations().contains("range") {
                 return invalid_schema_error(
                     "An element representing a range must have the annotation `range`.",
                 );
@@ -770,10 +770,7 @@ impl TypedRangeBoundaryValue {
         boundary: &Element,
         range_type: RangeType,
     ) -> IonSchemaResult<TypedRangeBoundaryValue> {
-        let range_boundary_type = if boundary
-            .annotations()
-            .any(|x| x == &Symbol::from("exclusive"))
-        {
+        let range_boundary_type = if boundary.annotations().contains("exclusive") {
             RangeBoundaryType::Exclusive
         } else {
             RangeBoundaryType::Inclusive

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -3,7 +3,6 @@ use crate::isl::isl_import::IslImportType;
 use crate::isl::IslVersion;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use ion_rs::element::Element;
-use ion_rs::Symbol;
 
 /// Provides public facing APIs for constructing ISL types programmatically for ISL 1.0
 pub mod v_1_0 {
@@ -146,7 +145,7 @@ impl IslTypeImpl {
         inline_imported_types: &mut Vec<IslImportType>, // stores the inline_imports that are discovered while loading this ISL type
     ) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
-        let contains_annotations = ion.annotations().any(|x| x == &Symbol::from("type"));
+        let contains_annotations = ion.annotations().contains("type");
 
         let ion_struct = try_to!(ion.as_struct());
 

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -132,7 +132,7 @@ impl IslTypeRefImpl {
         inline_imported_types: &mut Vec<IslImportType>,
     ) -> IonSchemaResult<Self> {
         use crate::isl::isl_type_reference::NullabilityModifier::*;
-        let nullability = if value.has_annotation("nullable") {
+        let nullability = if value.annotations().contains("nullable") {
             if isl_version == IslVersion::V1_0 {
                 Nullable
             } else {
@@ -140,7 +140,7 @@ impl IslTypeRefImpl {
                     "`nullable::` modifier is not supported since ISL 2.0",
                 );
             }
-        } else if value.has_annotation("$null_or") {
+        } else if value.annotations().contains("$null_or") {
             if isl_version != IslVersion::V1_0 {
                 NullOr
             } else {

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -133,7 +133,7 @@ impl Display for IonSchemaElement {
 
 impl From<&Element> for IonSchemaElement {
     fn from(value: &Element) -> Self {
-        if value.annotations().any(|a| a.text() == Some("document")) {
+        if value.annotations().contains("document") {
             let sequence = match value.ion_type() {
                 IonType::String => load(value.as_string().unwrap()),
                 IonType::List | IonType::SExp => {

--- a/ion-schema/src/nfa.rs
+++ b/ion-schema/src/nfa.rs
@@ -5,8 +5,8 @@ use crate::IonSchemaElement;
 use ion_rs::value::owned::Element;
 use std::collections::{HashMap, HashSet};
 use std::iter::Peekable;
-use std::rc::Rc;
 use std::slice::Iter;
+use std::sync::Arc;
 
 /// Represents an id for a state in NFA
 type StateId = usize;
@@ -117,11 +117,11 @@ impl NfaRun {
 #[derive(Debug, Clone)]
 pub struct NfaEvaluation {
     pub(crate) visits: HashSet<NfaRun>,
-    pub(crate) nfa: Rc<Nfa>,
+    pub(crate) nfa: Arc<Nfa>,
 }
 
 impl NfaEvaluation {
-    pub fn new(nfa: Rc<Nfa>) -> Self {
+    pub fn new(nfa: Arc<Nfa>) -> Self {
         Self {
             visits: {
                 let mut visits = HashSet::new();

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -9,7 +9,7 @@
 use crate::import::Import;
 use crate::system::{TypeId, TypeStore};
 use crate::types::{TypeDefinitionImpl, TypeRef};
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// A Schema is a collection of zero or more [`TypeRef`]s.
 ///
@@ -21,11 +21,11 @@ use std::rc::Rc;
 #[derive(Debug, Clone)]
 pub struct Schema {
     id: String,
-    types: Rc<TypeStore>,
+    types: Arc<TypeStore>,
 }
 
 impl Schema {
-    pub(crate) fn new<A: AsRef<str>>(id: A, types: Rc<TypeStore>) -> Self {
+    pub(crate) fn new<A: AsRef<str>>(id: A, types: Arc<TypeStore>) -> Self {
         Self {
             id: id.as_ref().to_owned(),
             types,
@@ -50,7 +50,7 @@ impl Schema {
 
     /// Returns an iterator over the imported types of this [`Schema`].
     fn imported_types(&self) -> SchemaTypeIterator {
-        SchemaTypeIterator::new(Rc::clone(&self.types), self.types.get_imports())
+        SchemaTypeIterator::new(Arc::clone(&self.types), self.types.get_imports())
     }
 
     /// Returns the requested type, if present in this schema or a a built in type;
@@ -59,13 +59,13 @@ impl Schema {
         let type_id = self
             .types
             .get_built_in_type_id_or_defined_type_id_by_name(name.as_ref())?;
-        Some(TypeRef::new(*type_id, Rc::clone(&self.types)))
+        Some(TypeRef::new(*type_id, Arc::clone(&self.types)))
     }
 
     /// Returns an iterator over the types in this schema.
     // This only includes named types defined within this schema.
     pub fn get_types(&self) -> SchemaTypeIterator {
-        SchemaTypeIterator::new(Rc::clone(&self.types), self.types.get_types())
+        SchemaTypeIterator::new(Arc::clone(&self.types), self.types.get_types())
     }
 
     /// Returns a new [`Schema`] instance containing all the types of this
@@ -79,13 +79,13 @@ impl Schema {
 
 /// Provides an Iterator which returns [`TypeRef`]s inside a [`Schema`]
 pub struct SchemaTypeIterator {
-    type_store: Rc<TypeStore>,
+    type_store: Arc<TypeStore>,
     index: usize,
     types: Vec<TypeId>,
 }
 
 impl SchemaTypeIterator {
-    fn new(type_store: Rc<TypeStore>, types: Vec<TypeId>) -> Self {
+    fn new(type_store: Arc<TypeStore>, types: Vec<TypeId>) -> Self {
         Self {
             type_store,
             index: 0,
@@ -104,7 +104,7 @@ impl Iterator for SchemaTypeIterator {
         self.index += 1;
         Some(TypeRef::new(
             self.types[self.index - 1],
-            Rc::clone(&self.type_store),
+            Arc::clone(&self.type_store),
         ))
     }
 }
@@ -118,6 +118,7 @@ mod schema_tests {
     use ion_rs::value::reader::element_reader;
     use ion_rs::value::reader::ElementReader;
     use rstest::*;
+    use std::sync::Arc;
 
     // helper function to be used by schema tests
     fn load(text: &str) -> Vec<Element> {
@@ -127,7 +128,7 @@ mod schema_tests {
     }
 
     // helper function to be used by validation tests
-    fn load_schema_from_text(text: &str) -> Rc<Schema> {
+    fn load_schema_from_text(text: &str) -> Arc<Schema> {
         let owned_elements = load(text).into_iter();
         // create a type_store and resolver instance to be used for loading Elements as schema
         let type_store = &mut TypeStore::default();
@@ -1114,7 +1115,7 @@ mod schema_tests {
     fn type_validation(
         valid_values: Vec<Element>,
         invalid_values: Vec<Element>,
-        schema: Rc<Schema>,
+        schema: Arc<Schema>,
         type_name: &str,
     ) {
         let type_ref: TypeRef = schema.get_type(type_name).unwrap();

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -763,7 +763,7 @@ impl Resolver {
 
         // add all types from pending_types to type_store
         pending_types.update_type_store(type_store, None, &isl_type_names)?;
-        Ok(Schema::new(id, Arc::new(type_store.to_owned())))
+        Ok(Schema::new(id, Arc::new(type_store.clone())))
     }
 
     /// Converts given owned elements into ISL v2.0 representation
@@ -948,7 +948,7 @@ impl Resolver {
             );
         }
 
-        let schema = Arc::new(Schema::new(isl.id(), Arc::new(type_store.to_owned())));
+        let schema = Arc::new(Schema::new(isl.id(), Arc::new(type_store.clone())));
 
         // add schema to schema cache
         // if we are loading an import of the schema then we can only add this schema to cache if its a full schema import

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -1064,6 +1064,11 @@ impl Resolver {
 }
 
 /// Provides functions for instantiating instances of [`Schema`].
+///
+/// [`SchemaSystem`] is *[Send and Sync]* i.e. it is safe to send it to another thread and to be shared between threads.
+/// For cases when one does need thread-safe interior mutability, they can use the explicit locking via [`std::sync::Mutex`] and [`std::sync::RwLock`].
+///
+/// [Send and Sync]: https://doc.rust-lang.org/nomicon/send-and-sync.html
 pub struct SchemaSystem {
     resolver: Resolver,
 }
@@ -2108,5 +2113,29 @@ mod schema_system_tests {
 
         // verify the resolved schema generated from the ISL 2.0 model that contains ISL 1.0 constraints is invalid
         assert!(&schema.is_err());
+    }
+
+    #[test]
+    fn test_send_schema() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Schema>();
+    }
+
+    #[test]
+    fn test_sync_schema() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Schema>();
+    }
+
+    #[test]
+    fn test_send_schema_system() {
+        fn assert_send<T: Send>() {}
+        assert_send::<SchemaSystem>();
+    }
+
+    #[test]
+    fn test_sync_schema_system() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<SchemaSystem>();
     }
 }

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -12,7 +12,7 @@ use ion_rs::value::owned::{text_token, Element};
 use ion_rs::value::{Builder, IonElement};
 use ion_rs::IonType;
 use std::fmt::{Display, Formatter};
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Provides validation for [`TypeDefinition`]
 pub trait TypeValidator {
@@ -40,11 +40,11 @@ pub trait TypeValidator {
 #[derive(Debug, Clone)]
 pub struct TypeRef {
     id: TypeId,
-    type_store: Rc<TypeStore>,
+    type_store: Arc<TypeStore>,
 }
 
 impl TypeRef {
-    pub fn new(id: TypeId, type_store: Rc<TypeStore>) -> Self {
+    pub fn new(id: TypeId, type_store: Arc<TypeStore>) -> Self {
         Self { id, type_store }
     }
 

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -6,8 +6,8 @@ use ion_schema::result::IonSchemaResult;
 use ion_schema::schema::Schema;
 use ion_schema::system::SchemaSystem;
 use ion_schema::types::TypeRef;
-use std::rc::Rc;
 use std::str;
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
 extern crate web_sys;
@@ -115,7 +115,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
     log!("created schema system successfully!");
 
     // Load schema
-    let schema_result: IonSchemaResult<Rc<Schema>> = schema_system.load_schema(schema_id);
+    let schema_result: IonSchemaResult<Arc<Schema>> = schema_system.load_schema(schema_id);
 
     match &schema_result {
         Ok(_) => {}
@@ -132,7 +132,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
         }
     };
 
-    let schema: Rc<Schema> = schema_result.unwrap();
+    let schema: Arc<Schema> = schema_result.unwrap();
 
     log!("loaded schema successfully!");
 


### PR DESCRIPTION
### Issue #151, #150

### Description of changes:
This PR works on making `SchemaSystem` [Send and Sync](https://doc.rust-lang.org/nomicon/send-and-sync.html).

* Adds changes for making `SchemaSystem` use `Arc` instead of `Rc`.
* Use `Arc` instead of `Rc` for `Schema` and `TypeStore`.
* Adds changes for inserting schema to `resolved_schema_cache` once its loaded.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
