### PR TITLE
Update `ion-rs` to `v0.16.0`

### DIFF
--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.15.0"
+ion-rs = "0.16.0"
 ion-schema = { path = "../ion-schema" }
 quote = "1.0.21"
 syn = "1.0.102"

--- a/ion-schema-tests-runner/src/model.rs
+++ b/ion-schema-tests-runner/src/model.rs
@@ -1,5 +1,4 @@
-use ion_rs::value::owned::{Element, Sequence, Struct};
-use ion_rs::value::{IonElement, IonSequence, IonStruct};
+use ion_rs::element::{Element, IonSequence, List, Struct};
 use std::ops::Deref;
 
 // Represents a single test case.
@@ -60,11 +59,11 @@ impl TryFrom<Element> for TestCaseVec {
                     .to_string()
                     .len();
 
-                for (i, value) in valid_schemas.iter().enumerate() {
+                for (i, value) in valid_schemas.elements().enumerate() {
                     let schema_text = value
                         .as_sequence()
                         .ok_or(format!("Malformed test case; the valid schemas must be embedded as s-expressions: {value}"))?
-                        .iter()
+                        .elements()
                         .fold("".to_string(), |s, e| format!("{s}\n{e}"));
                     the_vec_of_test_cases.push(TestCase {
                         description: format!("{base_description} [{i:0width$}]"),
@@ -76,11 +75,11 @@ impl TryFrom<Element> for TestCaseVec {
                 }
 
                 let i0 = valid_schemas.len();
-                for (i, value) in invalid_schemas.iter().enumerate() {
+                for (i, value) in invalid_schemas.elements().enumerate() {
                     let schema_text = value
                         .as_sequence()
                         .ok_or(format!("Malformed test case; the invalid schemas must be embedded as s-expressions: {value}"))?
-                        .iter()
+                        .elements()
                         .fold("".to_string(), |s, e| format!("{s}\n{e}"));
                     the_vec_of_test_cases.push(TestCase {
                         description: format!("{base_description} [{:0width$}]", i0 + i),
@@ -92,8 +91,8 @@ impl TryFrom<Element> for TestCaseVec {
                 }
             } else if test_case_struct.get("invalid_types").is_some() {
                 let invalid_types = test_case_struct.get_required_list_field("invalid_types")?;
-                let width = invalid_types.iter().count().to_string().len();
-                for (i, value) in invalid_types.iter().enumerate() {
+                let width = invalid_types.elements().count().to_string().len();
+                for (i, value) in invalid_types.elements().enumerate() {
                     the_vec_of_test_cases.push(TestCase {
                         description: format!("{base_description} [{i:0width$}]"),
                         details: TestCaseDetails::InvalidType {
@@ -113,7 +112,7 @@ impl TryFrom<Element> for TestCaseVec {
             let valid_values =
                 test_case_struct.get_optional_list_field("should_accept_as_valid")?;
             let width = valid_values.len().to_string().len();
-            for (i, value) in valid_values.iter().enumerate() {
+            for (i, value) in valid_values.elements().enumerate() {
                 the_vec_of_test_cases.push(TestCase {
                     description: format!("value should be valid for type {type_id} [{i:0width$}]"),
                     details: TestCaseDetails::Value {
@@ -127,7 +126,7 @@ impl TryFrom<Element> for TestCaseVec {
             let invalid_values =
                 test_case_struct.get_optional_list_field("should_reject_as_invalid")?;
             let width = invalid_values.len().to_string().len();
-            for (i, value) in invalid_values.iter().enumerate() {
+            for (i, value) in invalid_values.elements().enumerate() {
                 the_vec_of_test_cases.push(TestCase {
                     description: format!(
                         "value should be invalid for type {type_id} [{i:0width$}]"
@@ -161,8 +160,8 @@ impl TryFrom<Element> for TestCaseVec {
 // Helpers to DRY up the code when getting values from the test case struct
 trait StructUtils {
     fn get_required_text_field(&self, field_name: &str) -> Result<&str, String>;
-    fn get_required_list_field(&self, field_name: &str) -> Result<Sequence, String>;
-    fn get_optional_list_field(&self, field_name: &str) -> Result<Sequence, String>;
+    fn get_required_list_field(&self, field_name: &str) -> Result<List, String>;
+    fn get_optional_list_field(&self, field_name: &str) -> Result<List, String>;
 }
 
 impl StructUtils for Struct {
@@ -179,7 +178,7 @@ impl StructUtils for Struct {
                 field_name,
                 Element::from(self.clone())
             ))?;
-            field.as_str().ok_or(format!(
+            field.as_text().ok_or(format!(
                 "Malformed test case - field '{}' must be text: {}",
                 field_name,
                 Element::from(self.clone())
@@ -187,7 +186,7 @@ impl StructUtils for Struct {
         }
     }
 
-    fn get_required_list_field(&self, field_name: &str) -> Result<Sequence, String> {
+    fn get_required_list_field(&self, field_name: &str) -> Result<List, String> {
         if self.get(field_name).is_none() {
             Err(format!(
                 "Malformed test case - field '{}' is missing: {}",
@@ -199,7 +198,7 @@ impl StructUtils for Struct {
         }
     }
 
-    fn get_optional_list_field(&self, field_name: &str) -> Result<Sequence, String> {
+    fn get_optional_list_field(&self, field_name: &str) -> Result<List, String> {
         if self.get_all(field_name).count() > 1 {
             Err(format!(
                 "Malformed test case - field '{}' is repeated: {}",
@@ -207,14 +206,14 @@ impl StructUtils for Struct {
                 Element::from(self.clone())
             ))
         } else if let Some(field) = self.get(field_name) {
-            let seq = field.as_sequence().ok_or(format!(
+            let list = field.as_list().ok_or(format!(
                 "Malformed test case - field '{}' must be a list: {}",
                 field_name,
                 Element::from(self.clone())
             ))?;
-            Ok(seq.clone())
+            Ok(list.clone())
         } else {
-            Ok(Sequence::new(vec![]))
+            Ok(Element::list_builder().build())
         }
     }
 }

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.15.0"
+ion-rs = "0.16.0"
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/ion-schema/src/authority.rs
+++ b/ion-schema/src/authority.rs
@@ -102,7 +102,7 @@ impl DocumentAuthority for FileSystemDocumentAuthority {
         let absolute_path = self.base_path().join(id);
         // if absolute_path exists for the given id then load schema with file contents
         let ion_content = fs::read(absolute_path)?;
-        let schema_content = Element::read_all(&ion_content)?;
+        let schema_content = Element::read_all(ion_content)?;
         Ok(schema_content)
     }
 }

--- a/ion-schema/src/authority.rs
+++ b/ion-schema/src/authority.rs
@@ -61,9 +61,7 @@
 //! ```
 
 use crate::result::{unresolvable_schema_error_raw, IonSchemaResult};
-use ion_rs::result::IonError;
-use ion_rs::value::owned::Element;
-use ion_rs::value::reader::{element_reader, ElementReader};
+use ion_rs::element::Element;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs;
@@ -104,8 +102,7 @@ impl DocumentAuthority for FileSystemDocumentAuthority {
         let absolute_path = self.base_path().join(id);
         // if absolute_path exists for the given id then load schema with file contents
         let ion_content = fs::read(absolute_path)?;
-        let iterator = element_reader().iterate_over(&ion_content)?;
-        let schema_content = iterator.collect::<Result<Vec<Element>, IonError>>()?;
+        let schema_content = Element::read_all(&ion_content)?;
         Ok(schema_content)
     }
 }
@@ -136,8 +133,7 @@ impl DocumentAuthority for MapDocumentAuthority {
                 "MapDocumentAuthority does not contain schema with id: {id}"
             ))
         })?;
-        let iterator = element_reader().iterate_over(ion_content.as_bytes())?;
-        let schema_content = iterator.collect::<Result<Vec<Element>, IonError>>()?;
+        let schema_content = Element::read_all(ion_content.as_bytes())?;
         Ok(schema_content)
     }
 }

--- a/ion-schema/src/ion_path.rs
+++ b/ion-schema/src/ion_path.rs
@@ -1,5 +1,4 @@
-use ion_rs::value::owned::Element;
-use ion_rs::value::Builder;
+use ion_rs::element::Element;
 use ion_rs::Symbol;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
@@ -75,15 +74,15 @@ impl IonPath {
 
 impl From<IonPath> for Element {
     fn from(value: IonPath) -> Element {
-        let mut ion_path = vec![];
+        let mut ion_path = Element::sexp_builder();
         for parent in &value.ion_path_elements {
             let element = match parent {
                 IonPathElement::Index(index) => Element::from(*index as i64),
                 IonPathElement::Field(name) => Element::from(Symbol::from(name.as_str())),
             };
-            ion_path.push(element);
+            ion_path = ion_path.push(element);
         }
-        Element::new_sexp(ion_path.into_iter())
+        ion_path.build().into()
     }
 }
 

--- a/ion-schema/src/isl/isl_import.rs
+++ b/ion-schema/src/isl/isl_import.rs
@@ -1,6 +1,5 @@
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
-use ion_rs::value::owned::Element;
-use ion_rs::value::{IonElement, IonStruct};
+use ion_rs::element::Element;
 
 /// Represents an import in an ISL schema.
 /// For more information: `<https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#imports>`
@@ -24,7 +23,7 @@ impl IslImport {
     pub fn from_ion_element(value: &Element) -> IonSchemaResult<IslImport> {
         let import = try_to!(value.as_struct());
         let id = match import.get("id") {
-            Some(import_id) => try_to!(import_id.as_str()),
+            Some(import_id) => try_to!(import_id.as_string()),
             None => {
                 return Err(invalid_schema_error_raw(
                     "import must have an id field in its definition",
@@ -33,12 +32,12 @@ impl IslImport {
         };
 
         let type_name = match import.get("type") {
-            Some(type_name) => try_to!(type_name.as_str()),
+            Some(type_name) => try_to!(type_name.as_text()),
             None => return Ok(IslImport::Schema(id.to_owned())),
         };
 
         let alias = match import.get("as") {
-            Some(alias) => alias.as_str().map(|a| a.to_owned()),
+            Some(alias) => alias.as_text().map(|a| a.to_owned()),
             None => {
                 return Ok(IslImport::Type(IslImportType::new(
                     id.to_owned(),

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -2,8 +2,8 @@ use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
 use crate::isl::isl_import::IslImportType;
 use crate::isl::IslVersion;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
-use ion_rs::value::owned::{text_token, Element};
-use ion_rs::value::{IonElement, IonStruct};
+use ion_rs::element::Element;
+use ion_rs::Symbol;
 
 /// Provides public facing APIs for constructing ISL types programmatically for ISL 1.0
 pub mod v_1_0 {
@@ -146,7 +146,7 @@ impl IslTypeImpl {
         inline_imported_types: &mut Vec<IslImportType>, // stores the inline_imports that are discovered while loading this ISL type
     ) -> IonSchemaResult<Self> {
         let mut constraints = vec![];
-        let contains_annotations = ion.annotations().any(|x| x == &text_token("type"));
+        let contains_annotations = ion.annotations().any(|x| x == &Symbol::from("type"));
 
         let ion_struct = try_to!(ion.as_struct());
 
@@ -157,7 +157,7 @@ impl IslTypeImpl {
             ));
         }
         let type_name: Option<String> = match ion_struct.get("name") {
-            Some(name_element) => match name_element.as_sym() {
+            Some(name_element) => match name_element.as_symbol() {
                 Some(name_symbol) => match name_symbol.text() {
                     None => {
                         return Err(invalid_schema_error_raw(

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -6,9 +6,7 @@ use crate::result::{
 };
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::types::TypeDefinitionImpl;
-use ion_rs::value::owned::Element;
-use ion_rs::value::reader::{element_reader, ElementReader};
-use ion_rs::value::{IonElement, IonStruct};
+use ion_rs::element::Element;
 use ion_rs::IonType;
 
 /// Provides public facing APIs for constructing ISL type references programmatically for ISL 1.0
@@ -122,7 +120,7 @@ impl IslTypeRefImpl {
                     )
                 }
 
-                let type_name = value.as_sym().unwrap()
+                let type_name = value.as_symbol().unwrap()
                     .text()
                     .ok_or_else(|| {
                         invalid_schema_error_raw(
@@ -133,8 +131,7 @@ impl IslTypeRefImpl {
                 // check for nullable type reference
                 if value.annotations().any(|a| a.text() == Some("nullable")) {
                     let built_in_type_def = IslTypeRefImpl::get_nullable_type_reference_definition(type_name)?;
-                    let value = &element_reader()
-                        .read_one(built_in_type_def.as_bytes()).unwrap();
+                    let value = &Element::read_one(built_in_type_def.as_bytes()).unwrap();
                     return IslTypeRefImpl::from_ion_element(isl_version, value, inline_imported_types);
                 }
 

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -75,7 +75,7 @@
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::IslType;
 use crate::UserReservedFields;
-use ion_rs::value::owned::Element;
+use ion_rs::element::Element;
 use std::fmt::{Display, Formatter};
 
 pub mod isl_constraint;
@@ -254,23 +254,18 @@ mod isl_tests {
     use crate::isl::util::TimestampPrecision;
     use crate::isl::IslVersion;
     use crate::result::IonSchemaResult;
+    use ion_rs::element::Element;
     use ion_rs::types::decimal::*;
-    use ion_rs::types::integer::Integer as IntegerValue;
+    use ion_rs::types::integer::Int as IntegerValue;
     use ion_rs::types::timestamp::Timestamp;
-    use ion_rs::value::owned::text_token;
-    use ion_rs::value::owned::Element;
-    use ion_rs::value::reader::element_reader;
-    use ion_rs::value::reader::ElementReader;
+    use ion_rs::Symbol;
     use rstest::*;
     use std::io::Write;
-
     // helper function to create NamedIslType for isl tests
     fn load_named_type(text: &str) -> IslType {
         let type_def = IslTypeImpl::from_owned_element(
             IslVersion::V1_0,
-            &element_reader()
-                .read_one(text.as_bytes())
-                .expect("parsing failed unexpectedly"),
+            &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             &mut vec![],
         )
         .unwrap();
@@ -286,9 +281,7 @@ mod isl_tests {
     fn load_anonymous_type(text: &str) -> IslType {
         let type_def = IslTypeImpl::from_owned_element(
             IslVersion::V1_0,
-            &element_reader()
-                .read_one(text.as_bytes())
-                .expect("parsing failed unexpectedly"),
+            &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             &mut vec![],
         )
         .unwrap();
@@ -317,7 +310,7 @@ mod isl_tests {
             type_def.open_content(),
             vec![(
                 "unknown_constraint".to_owned(),
-                element_reader().read_one(r#""this is an open content field value""#.as_bytes())?
+                Element::read_one(r#""this is an open content field value""#.as_bytes())?
             )]
         );
         Ok(())
@@ -443,7 +436,7 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with annotations constraint as below:
                         { annotations: closed::[red, blue, green] }
                     "#),
-        anonymous_type([annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])])
+        anonymous_type([annotations(vec!["closed"], vec![Symbol::from("red").into(), Symbol::from("blue").into(), Symbol::from("green").into()])])
     ),
     case::precision_constraint(
         load_anonymous_type(r#" // For a schema with precision constraint as below:
@@ -467,7 +460,7 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with valid_values constraint as below:
                         { valid_values: [2, 3.5, 5e7, "hello", hi] }
                     "#),
-        anonymous_type([valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()])
+        anonymous_type([valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), Symbol::from("hi").into()]).unwrap()])
     ),
     case::valid_values_with_range_constraint(
         load_anonymous_type(r#" // For a schema with valid_values constraint as below:
@@ -519,9 +512,7 @@ mod isl_tests {
     // helper function to create a range
     fn load_range(text: &str) -> IonSchemaResult<Range> {
         Range::from_ion_element(
-            &element_reader()
-                .read_one(text.as_bytes())
-                .expect("parsing failed unexpectedly"),
+            &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             RangeType::Any,
         )
     }
@@ -529,9 +520,7 @@ mod isl_tests {
     // helper function to create a timestamp precision range
     fn load_timestamp_precision_range(text: &str) -> IonSchemaResult<Range> {
         Range::from_ion_element(
-            &element_reader()
-                .read_one(text.as_bytes())
-                .expect("parsing failed unexpectedly"),
+            &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             RangeType::TimestampPrecision,
         )
     }
@@ -539,9 +528,7 @@ mod isl_tests {
     // helper function to create a timestamp precision range
     fn load_number_range(text: &str) -> IonSchemaResult<Range> {
         Range::from_ion_element(
-            &element_reader()
-                .read_one(text.as_bytes())
-                .expect("parsing failed unexpectedly"),
+            &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             RangeType::NumberOrTimestamp,
         )
     }
@@ -832,7 +819,7 @@ mod isl_tests {
             Decimal::new(204, -1),
             Decimal::new(505, -1)
         ).unwrap(),
-        "range::[ 204d-1, 505d-1 ]"
+        "range::[ 20.4, 50.5 ]"
     ),
     case::range_with_timestamp(
         TimestampRange::new(

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -1,8 +1,8 @@
 use crate::isl::isl_range::{Range, RangeType};
 use crate::result::{invalid_schema_error, IonSchemaError};
+use ion_rs::element::Element;
 use ion_rs::types::timestamp::Precision;
-use ion_rs::value::owned::{text_token, Element};
-use ion_rs::value::IonElement;
+use ion_rs::Symbol;
 use ion_rs::Timestamp;
 use num_traits::abs;
 use std::cmp::Ordering;
@@ -170,12 +170,12 @@ impl TryFrom<&Element> for ValidValue {
     type Error = IonSchemaError;
 
     fn try_from(value: &Element) -> Result<Self, Self::Error> {
-        if value.annotations().any(|a| a == &text_token("range")) {
+        if value.annotations().any(|a| a == &Symbol::from("range")) {
             Ok(ValidValue::Range(Range::from_ion_element(
                 value,
                 RangeType::NumberOrTimestamp,
             )?))
-        } else if value.annotations().any(|a| a != &text_token("range")) {
+        } else if value.annotations().any(|a| a != &Symbol::from("range")) {
             invalid_schema_error(
                 "Annotations are not allowed for valid_values constraint except `range` annotation",
             )

--- a/ion-schema/src/nfa.rs
+++ b/ion-schema/src/nfa.rs
@@ -2,7 +2,7 @@ use crate::ion_path::IonPath;
 use crate::system::{TypeId, TypeStore};
 use crate::types::TypeValidator;
 use crate::IonSchemaElement;
-use ion_rs::value::owned::Element;
+use ion_rs::element::Element;
 use std::collections::{HashMap, HashSet};
 use std::iter::Peekable;
 use std::rc::Rc;

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -114,16 +114,12 @@ mod schema_tests {
     use super::*;
     use crate::isl::IslVersion;
     use crate::system::Resolver;
-    use ion_rs::value::owned::Element;
-    use ion_rs::value::reader::element_reader;
-    use ion_rs::value::reader::ElementReader;
+    use ion_rs::element::Element;
     use rstest::*;
 
     // helper function to be used by schema tests
     fn load(text: &str) -> Vec<Element> {
-        element_reader()
-            .read_all(text.as_bytes())
-            .expect("parsing failed unexpectedly")
+        Element::read_all(text.as_bytes()).expect("parsing failed unexpectedly")
     }
 
     // helper function to be used by validation tests

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -8,9 +8,9 @@ use crate::result::{IonSchemaResult, ValidationResult};
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::violation::{Violation, ViolationCode};
 use crate::IonSchemaElement;
-use ion_rs::value::owned::{text_token, Element};
-use ion_rs::value::{Builder, IonElement};
+use ion_rs::element::Element;
 use ion_rs::IonType;
+use ion_rs::Symbol;
 use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 
@@ -54,7 +54,7 @@ impl TypeRef {
 
     /// Provides the validation for the given value based on this schema type
     /// ```
-    /// use ion_rs::value::owned::Element;
+    /// use ion_rs::element::Element;
     /// use ion_schema::IonSchemaElement;
     /// use ion_schema::authority::{FileSystemDocumentAuthority, DocumentAuthority};
     /// use ion_schema::system::SchemaSystem;
@@ -464,7 +464,7 @@ impl TypeDefinitionImpl {
             let isl_constraint = IslConstraintImpl::from_ion_element(
                 isl_version,
                 "type",
-                &Element::new_symbol(text_token("any")),
+                &Element::symbol(Symbol::from("any")),
                 &isl_type_name,
                 &mut vec![],
             )?;
@@ -579,7 +579,7 @@ mod type_definition_tests {
     use crate::isl::isl_type_reference::v_1_0::*;
     use crate::system::PendingTypes;
     use ion_rs::Decimal;
-    use ion_rs::Integer;
+    use ion_rs::Int;
     use rstest::*;
     use std::collections::HashSet;
 
@@ -709,8 +709,8 @@ mod type_definition_tests {
         /* For a schema with annotations constraint as below:
             { annotations: closed::[red, blue, green] }
         */
-        anonymous_type([annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()])]),
-        TypeDefinition::anonymous([Constraint::annotations(vec!["closed"], vec![text_token("red").into(), text_token("blue").into(), text_token("green").into()]), Constraint::type_constraint(34)])
+        anonymous_type([annotations(vec!["closed"], vec![Symbol::from("red").into(), Symbol::from("blue").into(), Symbol::from("green").into()])]),
+        TypeDefinition::anonymous([Constraint::annotations(vec!["closed"], vec![Symbol::from("red").into(), Symbol::from("blue").into(), Symbol::from("green").into()]), Constraint::type_constraint(34)])
     ),
     case::precision_constraint(
         /* For a schema with precision constraint as below:
@@ -723,8 +723,8 @@ mod type_definition_tests {
         /* For a schema with scale constraint as below:
             { scale: 2 }
         */
-        anonymous_type([scale(Integer::I64(2).into())]),
-        TypeDefinition::anonymous([Constraint::scale(Integer::I64(2).into()), Constraint::type_constraint(34)])
+        anonymous_type([scale(Int::I64(2).into())]),
+        TypeDefinition::anonymous([Constraint::scale(Int::I64(2).into()), Constraint::type_constraint(34)])
     ),
     case::timestamp_precision_constraint(
         /* For a schema with timestamp_precision constraint as below:
@@ -737,8 +737,8 @@ mod type_definition_tests {
         /* For a schema with valid_values constraint as below:
             { valid_values: [2, 3.5, 5e7, "hello", hi] }
         */
-        anonymous_type([valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap()]),
-        TypeDefinition::anonymous([Constraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), text_token("hi").into()]).unwrap(), Constraint::type_constraint(34)])
+        anonymous_type([valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), Symbol::from("hi").into()]).unwrap()]),
+        TypeDefinition::anonymous([Constraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), Symbol::from("hi").into()]).unwrap(), Constraint::type_constraint(34)])
     ),
     case::valid_values_with_range_constraint(
         /* For a schema with valid_values constraint as below:
@@ -747,7 +747,7 @@ mod type_definition_tests {
         anonymous_type(
             [valid_values_with_range(
                 NumberRange::new(
-                    Number::from(&Integer::I64(1)),
+                    Number::from(&Int::I64(1)),
                     Number::from(&Decimal::new(55, -1))
                 ).unwrap().into())
             ]
@@ -755,7 +755,7 @@ mod type_definition_tests {
         TypeDefinition::anonymous([
             Constraint::valid_values_with_range(
             NumberRange::new(
-                Number::from(&Integer::I64(1)),
+                Number::from(&Int::I64(1)),
                 Number::from(&Decimal::new(55, -1))
             ).unwrap().into()),
             Constraint::type_constraint(34)

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -1,6 +1,6 @@
 use ion_schema::authority::{DocumentAuthority, MapDocumentAuthority};
-use ion_schema::external::ion_rs::value::owned::Element;
-use ion_schema::external::ion_rs::value::reader::{element_reader, ElementReader};
+
+use ion_schema::external::ion_rs::element::Element;
 use ion_schema::external::ion_rs::IonResult;
 use ion_schema::result::IonSchemaResult;
 use ion_schema::schema::Schema;
@@ -20,7 +20,7 @@ macro_rules! log {
 }
 
 fn load(text: &str) -> IonResult<Element> {
-    element_reader().read_one(text.as_bytes())
+    Element::read_one(text.as_bytes())
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
### Description of changes:
This PR works on updating dependency of `ion-rs` to v0.16.0 and adds related changes.

### List of changes:
* Uses full names for `as_*` methods:
  * `as_str` -> `as_string`
  * `as_int` -> `as_integer`
  * `as_sym` -> `as_symbol`
  * `as_f64` -> `as_float`
*  `element_reader().read_one()` -> `Element::read_one()`
* `element_reader().read_all()` ->`Element::read_all()` 
* Uses `Symbol::from(TEXT)` instead of `text_token(TEXT)`
* For List and Sexp (Sequences) change `iter()` -> `elements()`
* Uses new Element builders e.g. `list_builder()` , `sexp_builder()`

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
