### PR TITLE
adds implementation of `exponent` constraint for ISL 2.0

### DIFF
--- a/ion-schema-tests-runner/src/model.rs
+++ b/ion-schema-tests-runner/src/model.rs
@@ -167,11 +167,11 @@ trait StructUtils {
 impl StructUtils for Struct {
     fn get_required_text_field(&self, field_name: &str) -> Result<&str, String> {
         if self.get_all(field_name).count() > 1 {
-            return Err(format!(
+            Err(format!(
                 "Malformed test case - field '{}' is repeated: {}",
                 field_name,
                 Element::from(self.clone())
-            ));
+            ))
         } else {
             let field = self.get(field_name).ok_or(format!(
                 "Malformed test case - field '{}' is missing: {}",

--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -3,5 +3,33 @@ use ion_schema_tests_runner::ion_schema_tests;
 ion_schema_tests!(
     root = "ion-schema-tests/ion_schema_2_0/",
     // Support for ISL 2.0 is not implemented yet, so all tests are ignored.
-    ignored(".*")
+    ignored(
+        "open_content",
+        "imports",
+        "schema::*",
+        "constraints::all_of",
+        "constraints::annotations_simplified",
+        "constraints::annotations_standard",
+        "constraints::any_of",
+        "constraints::byte_length",
+        "constraints::codepoint_length",
+        "constraints::container_length",
+        "constraints::contains",
+        "constraints::element",
+        "constraints::field_names",
+        "constraints::fields",
+        "constraints::ieee754_float",
+        "constraints::not",
+        "constraints::one_of",
+        "constraints::ordered_elements",
+        "constraints::precision",
+        "constraints::regex",
+        "constraints::regex-invalid",
+        "constraints::timestamp_offset",
+        "constraints::timestamp_precision",
+        "constraints::type",
+        "constraints::utf8_byte_length",
+        "constraints::valid_values",
+        "constraints::valid_values-ranges"
+    )
 );

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -164,6 +164,10 @@ impl Constraint {
     pub fn scale(scale: RangeImpl<Int>) -> Constraint {
         Constraint::Scale(ScaleConstraint::new(Range::Integer(scale)))
     }
+    /// Creates a [Constraint::Exponent] from a [Range] specifying an exponent range.
+    pub fn exponent(exponent: RangeImpl<Int>) -> Constraint {
+        Constraint::Exponent(ExponentConstraint::new(Range::Integer(exponent)))
+    }
 
     /// Creates a [Constraint::TimestampPrecision] from a [Range] specifying a precision range.
     pub fn timestamp_precision(precision: RangeImpl<TimestampPrecision>) -> Constraint {

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -20,6 +20,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
 use std::iter::Peekable;
+use std::ops::Neg;
 use std::rc::Rc;
 use std::str::Chars;
 
@@ -50,6 +51,7 @@ pub enum Constraint {
     ContentClosed,
     ContainerLength(ContainerLengthConstraint),
     Element(ElementConstraint),
+    Exponent(ExponentConstraint),
     Fields(FieldsConstraint),
     Not(NotConstraint),
     OneOf(OneOfConstraint),
@@ -363,6 +365,9 @@ impl Constraint {
                     timestamp_offset.valid_offsets().to_vec(),
                 )))
             }
+            IslConstraintImpl::Exponent(exponent_range) => Ok(Constraint::Exponent(
+                ExponentConstraint::new(exponent_range.to_owned()),
+            )),
             IslConstraintImpl::TimestampPrecision(timestamp_precision_range) => {
                 Ok(Constraint::TimestampPrecision(
                     TimestampPrecisionConstraint::new(timestamp_precision_range.to_owned()),
@@ -426,6 +431,7 @@ impl Constraint {
             Constraint::Precision(precision) => precision.validate(value, type_store, ion_path),
             Constraint::Regex(regex) => regex.validate(value, type_store, ion_path),
             Constraint::Scale(scale) => scale.validate(value, type_store, ion_path),
+            Constraint::Exponent(exponent) => exponent.validate(value, type_store, ion_path),
             Constraint::TimestampOffset(timestamp_offset) => {
                 timestamp_offset.validate(value, type_store, ion_path)
             }
@@ -1593,7 +1599,7 @@ impl ConstraintValidator for ScaleConstraint {
     ) -> ValidationResult {
         // get scale of decimal value
         let value_scale = value
-            .expect_element_of_type(&[IonType::Decimal], "precision", ion_path)?
+            .expect_element_of_type(&[IonType::Decimal], "scale", ion_path)?
             .as_decimal()
             .unwrap()
             .scale();
@@ -1607,6 +1613,55 @@ impl ConstraintValidator for ScaleConstraint {
                 "scale",
                 ViolationCode::InvalidLength,
                 format!("expected scale {scale_range} found {value_scale}"),
+                ion_path,
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Implements Ion Schema's `exponent` constraint
+/// [exponent]: https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#exponent
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExponentConstraint {
+    exponent_range: Range,
+}
+
+impl ExponentConstraint {
+    pub fn new(exponent_range: Range) -> Self {
+        Self { exponent_range }
+    }
+
+    pub fn exponent(&self) -> &Range {
+        &self.exponent_range
+    }
+}
+
+impl ConstraintValidator for ExponentConstraint {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
+        // get exponent of decimal value
+        let value_exponent = value
+            .expect_element_of_type(&[IonType::Decimal], "exponent", ion_path)?
+            .as_decimal()
+            .unwrap()
+            .scale()
+            .neg();
+
+        // get isl decimal exponent as a range
+        let exponent_range: &Range = self.exponent();
+
+        // return a Violation if the value didn't follow exponent constraint
+        if !exponent_range.contains(&(value_exponent).into()) {
+            return Err(Violation::new(
+                "exponent",
+                ViolationCode::InvalidLength,
+                format!("expected exponent {exponent_range} found {value_exponent}"),
                 ion_path,
             ));
         }

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -260,6 +260,7 @@ pub mod v_2_0 {
     use crate::isl::IslVersion;
     use crate::result::IonSchemaResult;
     use ion_rs::element::Element;
+    use ion_rs::Int;
 
     /// Creates an [IslConstraint::Type] using the [IslTypeRef] referenced inside it
     // type is rust keyword hence this method is named type_constraint unlike other ISL constraint methods
@@ -331,6 +332,14 @@ pub mod v_2_0 {
         IslConstraint::new(
             IslVersion::V2_0,
             IslConstraintImpl::Precision(Range::NonNegativeInteger(precision)),
+        )
+    }
+
+    /// Creates a [IslConstraint::Exponent] from a [Range] specifying an exponent range.
+    pub fn exponent(exponent: RangeImpl<Int>) -> IslConstraint {
+        IslConstraint::new(
+            IslVersion::V2_0,
+            IslConstraintImpl::Exponent(Range::Integer(exponent)),
         )
     }
 

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -253,6 +253,7 @@ mod isl_tests {
     use crate::isl::isl_type_reference::v_1_0::*;
     use crate::isl::util::TimestampPrecision;
     use crate::isl::IslVersion;
+    use crate::isl::*;
     use crate::result::IonSchemaResult;
     use ion_rs::element::Element;
     use ion_rs::types::decimal::*;
@@ -261,7 +262,7 @@ mod isl_tests {
     use ion_rs::Symbol;
     use rstest::*;
     use std::io::Write;
-    // helper function to create NamedIslType for isl tests
+    // helper function to create NamedIslType for isl tests using ISL 1.0
     fn load_named_type(text: &str) -> IslType {
         let type_def = IslTypeImpl::from_owned_element(
             IslVersion::V1_0,
@@ -277,7 +278,7 @@ mod isl_tests {
         IslType::new(type_def, constraints)
     }
 
-    // helper function to create AnonymousIslType for isl tests
+    // helper function to create AnonymousIslType for isl tests using ISL 1.0
     fn load_anonymous_type(text: &str) -> IslType {
         let type_def = IslTypeImpl::from_owned_element(
             IslVersion::V1_0,
@@ -289,6 +290,22 @@ mod isl_tests {
             .constraints()
             .iter()
             .map(|c| IslConstraint::new(IslVersion::V1_0, c.to_owned()))
+            .collect();
+        IslType::new(type_def, constraints)
+    }
+
+    // helper function to create AnonymousIslType for isl tests using ISL 2.0
+    fn load_anonymous_type_v2_0(text: &str) -> IslType {
+        let type_def = IslTypeImpl::from_owned_element(
+            IslVersion::V2_0,
+            &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
+            &mut vec![],
+        )
+        .unwrap();
+        let constraints = type_def
+            .constraints()
+            .iter()
+            .map(|c| IslConstraint::new(IslVersion::V2_0, c.to_owned()))
             .collect();
         IslType::new(type_def, constraints)
     }
@@ -449,6 +466,12 @@ mod isl_tests {
                         { scale: 2 }
                     "#),
         anonymous_type([scale(IntegerValue::I64(2).into())])
+    ),
+    case::exponent_constraint(
+        load_anonymous_type_v2_0(r#" // For a schema with exponent constraint as below:
+                        { exponent: -2 }
+                    "#),
+        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::exponent(IntegerValue::I64(-2).into())])
     ),
     case::timestamp_precision_constraint(
         load_anonymous_type(r#" // For a schema with timestamp_precision constraint as below:

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -577,6 +577,7 @@ mod type_definition_tests {
     use crate::isl::isl_type::v_1_0::*;
     use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::v_1_0::*;
+    use crate::isl::*;
     use crate::system::PendingTypes;
     use ion_rs::Decimal;
     use ion_rs::Int;
@@ -725,6 +726,13 @@ mod type_definition_tests {
         */
         anonymous_type([scale(Int::I64(2).into())]),
         TypeDefinition::anonymous([Constraint::scale(Int::I64(2).into()), Constraint::type_constraint(34)])
+    ),
+    case::exponent_constraint(
+        /* For a schema with exponent constraint as below:
+            { exponent: -2 }
+        */
+        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::exponent(Int::I64(2).into())]),
+        TypeDefinition::anonymous([Constraint::exponent(Int::I64(2).into()), Constraint::type_constraint(34)])
     ),
     case::timestamp_precision_constraint(
         /* For a schema with timestamp_precision constraint as below:

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -729,7 +729,7 @@ mod type_definition_tests {
     ),
     case::exponent_constraint(
         /* For a schema with exponent constraint as below:
-            { exponent: -2 }
+            { exponent: 2 }
         */
         isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::exponent(Int::I64(2).into())]),
         TypeDefinition::anonymous([Constraint::exponent(Int::I64(2).into()), Constraint::type_constraint(34)])


### PR DESCRIPTION
### Description of changes:
This PR works on adding implementation of `exponent` constraint.

### Grammar:
```ANTLR
<EXPONENT> ::= exponent: <INT>
             | exponent: <RANGE_INT>
```

###  Ion Schema specification:
https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#exponent

### List of changes:
* adds changes for `exponent` constraint implementation
* adds `Exponent` enum variants for `IslConstraintImpl` and `Constraint`
* adds `ExponentConstraint` implementations
* adds validation logic for `exponent`
* adds changes for `Range` to expect only List types while parsing from ISL.
* adds changes for Integer ranges to return error for empty ranges for which there aren't any valid values. 
(e.g. `range::[exclusive::2, exclusive::3]`)

### Tests:
added unit tests for `exponent` implementation.
- adds tests for programmatically creating `exponent` constraint
- adds tests for loading a schema using `exponent` constraint 
- adds validation tests for `exponent` constraint
- adds test runner changes for `exponent` tests

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
