### PR TITLE
adds implementation of `element` constraint for ISL 2.0

### DIFF
--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -15,7 +15,7 @@ ion_schema_tests!(
         "constraints::codepoint_length",
         "constraints::container_length",
         "constraints::contains",
-        "constraints::element",
+        "constraints::element.*element_with_nullable_type", // This can be removed once we have implementation for `$null_or` annotation as per ISL 2.0
         "constraints::field_names",
         "constraints::fields",
         "constraints::ieee754_float",

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -181,7 +181,7 @@ pub mod v_1_0 {
     pub fn element(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::new(
             IslVersion::V1_0,
-            IslConstraintImpl::Element(isl_type.type_reference),
+            IslConstraintImpl::Element(isl_type.type_reference, None),
         )
     }
 
@@ -415,10 +415,12 @@ pub mod v_2_0 {
         )
     }
 
-    /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it
-    pub fn element(isl_type: IslTypeRef) -> IslConstraint {
-        // add support for `distinct::` elements
-        todo!()
+    /// Creates an [IslConstraint::Element] using the [IslTypeRef] referenced inside it and considers whether distinct elements are required or not
+    pub fn element(isl_type: IslTypeRef, require_distinct_elements: bool) -> IslConstraint {
+        IslConstraint::new(
+            IslVersion::V2_0,
+            IslConstraintImpl::Element(isl_type.type_reference, Some(require_distinct_elements)),
+        )
     }
 
     /// Creates an [IslConstraint::Annotations] using [str]s and [Element]s specified inside it
@@ -483,7 +485,9 @@ pub(crate) enum IslConstraintImpl {
     Contains(Vec<Element>),
     ContentClosed,
     ContainerLength(Range),
-    Element(IslTypeRefImpl),
+    // For ISL 2.0 true/false is specified based on whether `distinct` annotation is present or not.
+    // Represents Element(type_reference, expected_distinct). None here is used for ISL 1.0 which doesn't support `distinct` elements.
+    Element(IslTypeRefImpl, Option<bool>),
     Exponent(Range),
     Fields(HashMap<String, IslTypeRefImpl>),
     Not(IslTypeRefImpl),
@@ -610,7 +614,38 @@ impl IslConstraintImpl {
             "element" => {
                 let type_reference: IslTypeRefImpl =
                     IslTypeRefImpl::from_ion_element(isl_version, value, inline_imported_types)?;
-                Ok(IslConstraintImpl::Element(type_reference))
+                match isl_version {
+                    IslVersion::V1_0 => {
+                        // for ISL 1.0 `distinct annotation on `element` constraint is not supported which is represented by `None` here
+                        Ok(IslConstraintImpl::Element(type_reference, None))
+                    }
+                    IslVersion::V2_0 => {
+                        // return error if there are any annotations other than `distinct` or `$null_or`
+                        if value
+                            .annotations()
+                            .any(|a| a.text() != Some("distinct") && a.text() != Some("$null_or"))
+                        {
+                            return Err(invalid_schema_error_raw(
+                                "element constraint can only contain `distinct` annotation",
+                            ));
+                        }
+
+                        // verify whether `distinct`annotation is present or not
+                        let require_distinct = value.has_annotation("distinct");
+
+                        // return error if the type reference contains `occurs` constraint
+                        if type_reference.get_occurs_constraint() {
+                            return Err(invalid_schema_error_raw(
+                                "element constraint can not contain type references that contain `occurs` constraint",
+                            ));
+                        }
+
+                        Ok(IslConstraintImpl::Element(
+                            type_reference,
+                            Some(require_distinct),
+                        ))
+                    }
+                }
             }
             "fields" => {
                 let fields: HashMap<String, IslTypeRefImpl> =

--- a/ion-schema/src/isl/isl_import.rs
+++ b/ion-schema/src/isl/isl_import.rs
@@ -23,7 +23,7 @@ impl IslImport {
     pub fn from_ion_element(value: &Element) -> IonSchemaResult<IslImport> {
         let import = try_to!(value.as_struct());
         let id = match import.get("id") {
-            Some(import_id) => try_to!(import_id.as_string()),
+            Some(import_id) => try_to!(import_id.as_text()),
             None => {
                 return Err(invalid_schema_error_raw(
                     "import must have an id field in its definition",

--- a/ion-schema/src/isl/isl_range.rs
+++ b/ion-schema/src/isl/isl_range.rs
@@ -89,6 +89,10 @@ impl Range {
 
     /// Provides a boolean value to specify whether the given value is within the range or not
     pub fn contains(&self, value: &Element) -> bool {
+        if value.is_null() {
+            // if the provided Element is null, then return false
+            return false;
+        }
         match self {
             Range::Integer(int_range) if value.ion_type() == IonType::Int => {
                 int_range.contains(value.as_int().unwrap().to_owned())

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -6,6 +6,7 @@ use crate::result::{
 };
 use crate::system::{PendingTypes, TypeId, TypeStore};
 use crate::types::TypeDefinitionImpl;
+use crate::IslConstraintImpl;
 use ion_rs::element::Element;
 use ion_rs::IonType;
 
@@ -104,6 +105,19 @@ impl IslTypeRefImpl {
                 )
             }
         })
+    }
+
+    /// Verifies if the given type reference contains an `occurs` field or not
+    // This is used to make sure only `ordered_elements` and `fields` constraint can contain `occurs`.
+    // This method returns `false` for `Named` or `TypeImport` type references because `occurs` field is not allowed within named type definitions.
+    pub fn get_occurs_constraint(&self) -> bool {
+        match self {
+            IslTypeRefImpl::Anonymous(anonymous_type_def) => anonymous_type_def
+                .constraints()
+                .iter()
+                .any(|c| matches!(c, IslConstraintImpl::Occurs(_))),
+            _ => false,
+        }
     }
 
     /// Tries to create an [IslTypeRef] from the given Element

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -449,6 +449,12 @@ mod isl_tests {
                 "#),
         anonymous_type([element(named_type_ref("int"))])
     ),
+    case::distinct_element_constraint(
+        load_anonymous_type_v2_0(r#" // For a schema with distinct element constraint as below:
+                        { element: distinct::int }
+                    "#),
+    isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::element(named_type_ref("int"), true)])
+    ),
     case::annotations_constraint(
         load_anonymous_type(r#" // For a schema with annotations constraint as below:
                         { annotations: closed::[red, blue, green] }

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -237,6 +237,13 @@ mod schema_tests {
                  "#).into_iter(),
         1 // this includes named type element_type
     ),
+    case::distinct_element_constraint(
+        load(r#" // For a schema with distinct element constraint as below:
+                        $ion_schema_2_0
+                        type:: { name: distinct_element_type, element: distinct::int }
+                     "#).into_iter(),
+        1 // this includes named type distinct_element_type
+    ),
     case::annotations_constraint(
         load(r#" // For a schema with annotations constraint as below:
                     type:: { name: annotations_type, annotations: closed::[red, blue, green] }
@@ -876,6 +883,37 @@ mod schema_tests {
                                 type::{ name: element_type, element: int }
                         "#),
                 "element_type"
+        ),
+        case::distinct_element_constraint(
+                load(r#"
+                          []
+                          [1]
+                          [1, 2, 3]
+                          ()
+                          (1)
+                          (1 2 3)
+                          { a: 1, b: 2, c: 3 }
+                        "#),
+                load(r#"
+                          null.list
+                          [1.]
+                          [1e0]
+                          [1, 1, 2, 3]
+                          [a::1, b::1, a::2, a::2, 3]
+                          [1, 2, null.int]
+                          (1 2 3 true 4)
+                          (1 1 2 2 3)
+                          (a::1 b::1 a::2 a::2 3)
+                          { a: 1, b: 2, c: true }
+                          { a: 1, b: 1 }
+                          { a: c::1, b: c::1 }
+                          { a: 1, b: 2, c: null.int }
+                        "#),
+                load_schema_from_text(r#" // For a schema with distinct element constraint as below:
+                                $ion_schema_2_0
+                                type::{ name: distinct_element_type, element: distinct::int }
+                        "#),
+                "distinct_element_type"
         ),
         case::element_with_self_ref_type_constraint(
                 load(r#"

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -21,7 +21,7 @@
 
 use crate::authority::DocumentAuthority;
 use crate::external::ion_rs::Symbol;
-use crate::isl::isl_constraint::IslConstraint;
+use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::{IslType, IslTypeImpl};
 use crate::isl::{IslSchema, IslVersion};
@@ -793,6 +793,17 @@ impl Resolver {
 
                 if isl_version == IslVersion::V2_0 {
                     isl_user_reserved_fields.validate_field_names_in_type(&isl_type)?;
+                }
+
+                // top level named type definition can not contain `occurs` field as per ISL specification
+                if isl_type
+                    .constraints()
+                    .iter()
+                    .any(|c| matches!(c, IslConstraintImpl::Occurs(_)))
+                {
+                    return invalid_schema_error(
+                        "Top level types must not contain `occurs` field in their definition",
+                    );
                 }
 
                 let constraints = isl_type

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -706,6 +706,13 @@ mod type_definition_tests {
         anonymous_type([element(named_type_ref("int"))]),
         TypeDefinition::anonymous([Constraint::element(0), Constraint::type_constraint(34)])
     ),
+    case::distinct_element_constraint(
+        /* For a schema with distinct element constraint as below:
+            { element: distinct::int }
+        */
+        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::element(named_type_ref("int"), true)]),
+        TypeDefinition::anonymous([Constraint::distinct_element(0), Constraint::type_constraint(34)])
+    ),
     case::annotations_constraint(
         /* For a schema with annotations constraint as below:
             { annotations: closed::[red, blue, green] }

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -62,7 +62,8 @@ impl fmt::Display for Violation {
 pub enum ViolationCode {
     AllTypesNotMatched,
     AnnotationMismatched,
-    ElementMismatched, // this is used for mismatched elements in containers
+    ElementMismatched,  // this is used for mismatched elements in containers
+    ElementNotDistinct, // this is used for elements that are not distinct in containers
     FieldsNotMatched,
     InvalidLength, // this is ued for any length related constraints (e.g. container_length, byte_length, codepoint_length)
     InvalidNull,   // if the value is a null for type references that doesn't allow null
@@ -88,6 +89,7 @@ impl fmt::Display for ViolationCode {
                 ViolationCode::AllTypesNotMatched => "all_types_not_matched",
                 ViolationCode::AnnotationMismatched => "annotation_mismatched",
                 ViolationCode::ElementMismatched => "element_mismatched",
+                ViolationCode::ElementNotDistinct => "element_not_distinct",
                 ViolationCode::FieldsNotMatched => "fields_not_matched",
                 ViolationCode::InvalidLength => "invalid_length",
                 ViolationCode::InvalidNull => "invalid_null",


### PR DESCRIPTION
### Description of changes:
This PR works on adding implementation of `element` constraint with `distinct` annotation for ISL 2.0.

### Grammar:
```ANTLR
<ELEMENT> ::= element: <TYPE_REFERENCE>
            | element: distinct::<TYPE_REFERENCE>
```

###  Ion Schema specification:
https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#element

### List of changes:
* adds changes for `element` constraint implementation
* adds check for `distinct` annotation when constructing `ElementConstraint`
* `ElementConstraint` now stores `require_distinct_elements` property which is a boolean and used for validation of distinct elements
* adds validation logic for distinct elements
* add check for null value for range `contains` method
* adds check to verify there is no occurs field on `element`
constraints' type reference
* adds new `ViolationCode` for `ElementNotDistinct`
* adds check for verifying there is no `occurs` field on top level type
definition when loading schema

### Tests:
added unit tests for distinct elements
- adds tests for programmatically creating distinct `element` constraint
- adds tests for loading a schema using distinct `element` constraint 
- adds validation tests for distinct elements
- adds test runner changes for ISL 2.0 `element` tests

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
