### PR TITLE
adds struct fields related constraints for ISL 2.0

### DIFF
--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -16,7 +16,6 @@ ion_schema_tests!(
         "constraints::container_length",
         "constraints::contains",
         "constraints::field_names",
-        "constraints::fields",
         "constraints::ieee754_float",
         "constraints::not",
         "constraints::one_of",

--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -15,7 +15,6 @@ ion_schema_tests!(
         "constraints::codepoint_length",
         "constraints::container_length",
         "constraints::contains",
-        "constraints::field_names",
         "constraints::ieee754_float",
         "constraints::not",
         "constraints::one_of",

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -358,7 +358,11 @@ impl Constraint {
                     *require_distinct_elements,
                 )))
             }
-            IslConstraintImpl::Fields(fields) => {
+            IslConstraintImpl::Fields(fields, content_closed) => {
+                let open_content = match isl_version {
+                    IslVersion::V1_0 => open_content,
+                    IslVersion::V2_0 => !content_closed, // for ISL 2.0 whether open content is allowed or not depends on `fields` constraint
+                };
                 let fields_constraint: FieldsConstraint =
                     FieldsConstraint::resolve_from_isl_constraint(
                         isl_version,

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -427,6 +427,12 @@ mod isl_tests {
                 "#),
         anonymous_type([fields(vec![("name".to_owned(), named_type_ref("string")), ("id".to_owned(), named_type_ref("int"))].into_iter())]),
     ),
+    case::field_names_constraint(
+        load_anonymous_type_v2_0(r#" // For a schema with field_names constraint as below:
+                        { field_names: distinct::symbol }
+                    "#),
+        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::field_names(isl_type_reference::v_2_0::named_type_ref("symbol"), true)]),
+    ),
     case::contains_constraint(
         load_anonymous_type(r#" // For a schema with contains constraint as below:
                     { contains: [true, 1, "hello"] }

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -740,6 +740,25 @@ mod schema_tests {
         ),
         case::fields_constraint_with_closed_content(
                 load(r#"
+                         { name: "Ion", id: 1 }
+                         { id: 1 }
+                         { name: "Ion" }
+                         { name: "Ion", id: 1, name: "Schema" }
+                         { } // This is valid because all fields are optional
+                         { greetings: "hello" } // This is valid because open content is allowed by default
+                    "#),
+                load(r#"
+                        null.struct
+                        null
+                        { name: "Ion", id: 1, id: 2 }
+                    "#),
+                load_schema_from_text(r#" // For a schema with fields constraint as below:
+                            type:: { name: fields_type,  fields: { name: { type: string, occurs: range::[0,2] }, id: int } }
+                    "#),
+                "fields_type"
+        ),
+        case::fields_constraint_with_closed_annotation(
+                load(r#"
                      { name: "Ion", id: 1 }
                      { id: 1 }
                      { name: "Ion" }
@@ -752,8 +771,9 @@ mod schema_tests {
                     { name: "Ion", id: 1, id: 2 }
                     { greetings: "hello" }
                 "#),
-                load_schema_from_text(r#" // For a schema with fields constraint as below:
-                        type:: { name: fields_type,  content: closed, fields: { name: { type: string, occurs: range::[0,2] }, id: int } }
+                load_schema_from_text(r#" // For a schema with fields constraint with `closed` annotation as below:
+                        $ion_schema_2_0
+                        type:: { name: fields_type, fields: closed::{ name: { type: string, occurs: range::[0,2] }, id: int } }
                 "#),
                 "fields_type"
         ),

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -207,6 +207,13 @@ mod schema_tests {
             "#).into_iter(),
         1 // this includes named type fields_type
     ),
+    case::field_names_constraint(
+        load(r#" // For a schema with field_names constraint as below:
+                    $ion_schema_2_0
+                    type:: { name: field_names_type, field_names: distinct::symbol } 
+            "#).into_iter(),
+        1 // this includes named type field_names_type
+    ),
     case::contains_constraint(
         load(r#" // For a schema with contains constraint as below:
                 type:: { name: contains_type, contains: [true, 1, "hello"] }
@@ -776,6 +783,25 @@ mod schema_tests {
                         type:: { name: fields_type, fields: closed::{ name: { type: string, occurs: range::[0,2] }, id: int } }
                 "#),
                 "fields_type"
+        ),
+        case::field_names_constraint(
+                load(r#"
+                     { name: "Ion", id: 1 }
+                     { id: 1 }
+                     { name: "Ion" }
+                     { }
+                "#),
+                load(r#"
+                    null.struct
+                    null
+                    { name: "Ion", id: 1, name: "Schema" }
+                    { name: "Ion", id: 1, id: 2 }
+                "#),
+                load_schema_from_text(r#" // For a schema with field_names constraint as below:
+                        $ion_schema_2_0
+                        type:: { name: field_names_type, field_names: distinct::symbol }
+                "#),
+                "field_names_type"
         ),
         case::contains_constraint(
                 load(r#"

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -699,6 +699,13 @@ mod type_definition_tests {
         anonymous_type([fields(vec![("name".to_owned(), named_type_ref("string")), ("id".to_owned(), named_type_ref("int"))].into_iter())]),
     TypeDefinitionKind::anonymous([Constraint::fields(vec![("name".to_owned(), 4), ("id".to_owned(), 0)].into_iter()), Constraint::type_constraint(34)])
     ),
+    case::field_names_constraint(
+        /* For a schema with field_names constraint as below:
+            { field_names: distinct::symbol }
+        */
+    isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::field_names(named_type_ref("symbol"), true)]),
+    TypeDefinitionKind::anonymous([Constraint::distinct_field_names(5), Constraint::type_constraint(34)])
+    ),
     case::contains_constraint(
         /* For a schema with contains constraint as below:
             { contains: [true, 1, "hello"] }


### PR DESCRIPTION
### Issue #167, #159:

### Description of changes:
This PR works on adding struct fields related constraint `field_names` and `closed::` modifier for `fields` constraint.

### List of changes: 
-  adds changes for `field_names` constraint implementation
-  adds `FieldNames` enum variants for `IslConstraintImpl` and `Constraint`
-  adds `FieldNamesConstraint` implementations
-  adds validation logic for `field_names`
-  adds changes for `closed::` modifier for `fields` constraint as per ISL 2.0
-  adds unit tests for `field_names` constraint and `closed::` modifier.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
