### PR TITLE
bumps version to 0.7.0

### DIFF
--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion-schema-tests-runner"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion-schema-tests-runner"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 
 [lib]

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-schema-schemas/isl/**",
     "*.pdf"
 ]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
### Description of changes:

This PR bumps `ion-schema` version to 0.7.0 and `ion-schema-tests-runner` version to v0.2.0.
 
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
