### PR TITLE
modifies `wasm-schema-sandbox` to use flattened violations

### DIFF
--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -59,6 +59,9 @@ impl Violation {
 
     /// Provides flattened list of violations that only represent the leaf violations or core violations.
     pub fn flattened_violations(&self) -> Vec<&Violation> {
+        if self.violations.is_empty() {
+            return vec![self];
+        }
         let mut flattened_violations = Vec::new();
         for violation in &self.violations {
             if violation.violations.is_empty() {

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -45,6 +45,31 @@ impl Violation {
         }
     }
 
+    pub fn ion_path(&self) -> &IonPath {
+        &self.ion_path
+    }
+
+    pub fn message(&self) -> &String {
+        &self.message
+    }
+
+    pub fn code(&self) -> &ViolationCode {
+        &self.code
+    }
+
+    /// Provides flattened list of violations that only represent the leaf violations or core violations.
+    pub fn flattened_violations(&self) -> Vec<&Violation> {
+        let mut flattened_violations = Vec::new();
+        for violation in &self.violations {
+            if violation.violations.len() == 0 {
+                flattened_violations.push(violation);
+            } else {
+                flattened_violations.extend_from_slice(&*violation.flattened_violations())
+            }
+        }
+        flattened_violations
+    }
+
     pub fn violations(&self) -> &[Violation] {
         &self.violations
     }

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -61,10 +61,10 @@ impl Violation {
     pub fn flattened_violations(&self) -> Vec<&Violation> {
         let mut flattened_violations = Vec::new();
         for violation in &self.violations {
-            if violation.violations.len() == 0 {
+            if violation.violations.is_empty() {
                 flattened_violations.push(violation);
             } else {
-                flattened_violations.extend_from_slice(&*violation.flattened_violations())
+                flattened_violations.extend_from_slice(&violation.flattened_violations())
             }
         }
         flattened_violations

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -57,20 +57,24 @@ impl Violation {
         &self.code
     }
 
-    /// Provides flattened list of violations that only represent the leaf violations or core violations.
+    /// Provides flattened list of leaf violations which represent the root cause of the top-level violation.
     pub fn flattened_violations(&self) -> Vec<&Violation> {
-        if self.violations.is_empty() {
-            return vec![self];
-        }
         let mut flattened_violations = Vec::new();
+        self.flatten_violations(&mut flattened_violations);
+        flattened_violations
+    }
+
+    fn flatten_violations<'a>(&'a self, flattened: &mut Vec<&'a Violation>) {
+        if self.violations.is_empty() {
+            flattened.push(self);
+        }
         for violation in &self.violations {
             if violation.violations.is_empty() {
-                flattened_violations.push(violation);
+                flattened.push(violation);
             } else {
-                flattened_violations.extend_from_slice(&violation.flattened_violations())
+                violation.flatten_violations(flattened)
             }
         }
-        flattened_violations
     }
 
     pub fn violations(&self) -> &[Violation] {

--- a/wasm-schema-sandbox/Cargo.toml
+++ b/wasm-schema-sandbox/Cargo.toml
@@ -9,6 +9,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2.82"
+serde = { version = "1.0", features = ["derive"] }
+serde-wasm-bindgen = "0.4"
+js-sys = "0.3.61"
 ion-schema = { path="../ion-schema" }
 
 [dependencies.web-sys]

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -173,13 +173,8 @@ pub fn validate(
     let values_result = load_all(ion);
 
     let value = match values_result {
-        Ok(v) => {
-            if is_document {
-                IonSchemaElement::Document(v)
-            } else {
-                IonSchemaElement::SingleElement(v[0].to_owned())
-            }
-        }
+        Ok(v) if is_document => IonSchemaElement::Document(v),
+        Ok(v) => IonSchemaElement::SingleElement(v[0].to_owned()),
         Err(_) => {
             return SchemaValidationResult::new(
                 false,

--- a/wasm-schema-sandbox/src/lib.rs
+++ b/wasm-schema-sandbox/src/lib.rs
@@ -6,6 +6,10 @@ use ion_schema::result::IonSchemaResult;
 use ion_schema::schema::Schema;
 use ion_schema::system::SchemaSystem;
 use ion_schema::types::TypeDefinition;
+use ion_schema::IonSchemaElement;
+use js_sys::Array;
+use serde::{Deserialize, Serialize};
+use serde_wasm_bindgen::to_value;
 use std::str;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
@@ -19,14 +23,21 @@ macro_rules! log {
     }
 }
 
-fn load(text: &str) -> IonResult<Element> {
-    Element::read_one(text.as_bytes())
+fn load_all(text: &str) -> IonResult<Vec<Element>> {
+    Element::read_all(text.as_bytes())
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ViolationResult {
+    ion_path: String,
+    code: String,
+    message: String,
 }
 
 #[wasm_bindgen]
 pub struct SchemaValidationResult {
     result: bool,
-    violation: String,
+    violations: Array,
     value: String,
     has_error: bool,
     error: String,
@@ -37,14 +48,14 @@ impl SchemaValidationResult {
     #[wasm_bindgen(constructor)]
     pub fn new(
         r: bool,
-        v: String,
+        v: Array,
         val: String,
         has_error: bool,
         error: String,
     ) -> SchemaValidationResult {
         SchemaValidationResult {
             result: r,
-            violation: v,
+            violations: v,
             value: val,
             has_error,
             error,
@@ -57,14 +68,6 @@ impl SchemaValidationResult {
 
     pub fn set_result(&mut self, val: bool) {
         self.result = val;
-    }
-
-    pub fn violation(&self) -> String {
-        self.violation.to_owned()
-    }
-
-    pub fn set_violation(&mut self, val: String) {
-        self.violation = val;
     }
 
     pub fn value(&self) -> String {
@@ -90,10 +93,19 @@ impl SchemaValidationResult {
     pub fn set_has_error(&mut self, val: bool) {
         self.has_error = val;
     }
+
+    pub fn violations(&self) -> Array {
+        self.violations.to_owned()
+    }
 }
 
 #[wasm_bindgen]
-pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationResult {
+pub fn validate(
+    ion: &str,
+    schema: &str,
+    schema_type: &str,
+    is_document: bool,
+) -> SchemaValidationResult {
     // Provide schema id for the schema you want to load (schema_id is the schema file name here)
     // This will be the id of schema, provided within the map authority defined below
     let schema_id = "schema.isl";
@@ -123,7 +135,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
             // TODO: once we have a better Display for _error, replace the error portion of SchemaValidationResult to take this _error
             return SchemaValidationResult::new(
                 false,
-                "".to_string(),
+                Array::new(),
                 ion.to_string(),
                 true,
                 "Can not load given schema!\nPlease check Ion schema syntax for given schema."
@@ -144,7 +156,7 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
         None => {
             return SchemaValidationResult::new(
                 false,
-                "".to_string(),
+                Array::new(),
                 ion.to_string(),
                 true,
                 format!("Type definition: {schema_type} does not exist in this schema"),
@@ -158,14 +170,20 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
     );
 
     // get Element from given ion text
-    let value_result = load(ion);
+    let values_result = load_all(ion);
 
-    let value = match value_result {
-        Ok(v) => v,
+    let value = match values_result {
+        Ok(v) => {
+            if is_document {
+                IonSchemaElement::Document(v)
+            } else {
+                IonSchemaElement::SingleElement(v[0].to_owned())
+            }
+        }
         Err(_) => {
             return SchemaValidationResult::new(
                 false,
-                "".to_string(),
+                Array::new(),
                 ion.to_string(),
                 true,
                 format!("Can not parse given Ion value: {ion} for validation"),
@@ -176,23 +194,30 @@ pub fn validate(ion: &str, schema: &str, schema_type: &str) -> SchemaValidationR
     log!("loaded ion value successfully!");
 
     // Validate data based on `schema_type`
-    let result = type_ref.validate(&value);
+    let result = type_ref.validate(value.to_owned());
 
     log!("validation complete!");
 
-    let violation = match &result {
-        Ok(_) => "".to_string(),
-        Err(violation) => {
-            //TODO: Once we have a Display implementation with proper indentation for nested violations change the following
-            format!("{violation:#?}")
-        }
+    let violations = match &result {
+        Ok(_) => vec![],
+        Err(violation) => violation.flattened_violations(),
     };
 
     log!("Creating validation result....");
 
+    let violations_result = Array::new();
+    for violation in violations {
+        let v_result = ViolationResult {
+            ion_path: format!("{}", violation.ion_path()),
+            code: format!("{}", violation.code()),
+            message: violation.message().to_string(),
+        };
+        violations_result.push(&to_value(&v_result).unwrap());
+    }
+
     let result: SchemaValidationResult = SchemaValidationResult::new(
         result.is_ok(),
-        violation,
+        violations_result,
         format!("{value}"),
         false,
         "".to_string(),


### PR DESCRIPTION
### Description of changes:
This PR works on adding `flattened_violations()` that gets the leaf/core violations. This will be useful for `wasm-schema-sandbox` to include only the core violations.

### List of changes:
- adds `flattened_violations()` to `Violation`.
-  adds accessor methods `ion_path`, `code`, `message` for `Violation`.
- adds changes for wasm methods to use `flattened_violations()` to render violations in sandbox.

### Rendered view
https://desaikd.github.io/ion-schema/sandbox 

### Next Steps:
Create PR for the rendered view in `ion-schema` repository

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
