### PR TITLE
adds implementation of `ieee754_float` constraint

### DIFF
--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -15,7 +15,7 @@ ion_schema_tests!(
         "constraints::codepoint_length",
         "constraints::container_length",
         "constraints::contains",
-        "constraints::ieee754_float",
+        // "constraints::ieee754_float",
         "constraints::not",
         "constraints::one_of",
         "constraints::ordered_elements",

--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -15,7 +15,6 @@ ion_schema_tests!(
         "constraints::codepoint_length",
         "constraints::container_length",
         "constraints::contains",
-        // "constraints::ieee754_float",
         "constraints::not",
         "constraints::one_of",
         "constraints::ordered_elements",

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -28,6 +28,7 @@ num-bigint = "0.3"
 num-traits = "0.2"
 chrono = "0.4"
 regex = "1.5.6"
+half = "2.2.1"
 
 [dev-dependencies]
 rstest = "0.9"

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -742,11 +742,6 @@ impl IslConstraintImpl {
                 }
             }
             "ieee754_float" => {
-                if value.is_null() {
-                    return invalid_schema_error(
-                        "expected a symbol for an `ieee754_float` constraint, found null",
-                    );
-                }
                 if !value.annotations().is_empty() {
                     return invalid_schema_error(
                         "`ieee_754_float` argument must not have annotations",

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -256,7 +256,9 @@ pub mod v_2_0 {
     };
     use crate::isl::isl_range::{NonNegativeIntegerRange, Range, RangeImpl};
     use crate::isl::isl_type_reference::IslTypeRef;
-    use crate::isl::util::{TimestampOffset, TimestampPrecision, ValidValue};
+    use crate::isl::util::{
+        Ieee754InterchangeFormat, TimestampOffset, TimestampPrecision, ValidValue,
+    };
     use crate::isl::IslVersion;
     use crate::result::IonSchemaResult;
     use ion_rs::element::Element;
@@ -464,6 +466,14 @@ pub mod v_2_0 {
     /// Creates a `regex` constraint using the expression and flags (case_insensitive, multi_line)
     pub fn regex(case_insensitive: bool, multi_line: bool, expression: String) -> IslConstraint {
         todo!()
+    }
+
+    /// Creates a `ieee754_float` constraint using `Ieee754InterchangeFormat` specified in it.
+    pub fn ieee754_float(interchange_format: Ieee754InterchangeFormat) -> IslConstraint {
+        IslConstraint::new(
+            IslVersion::V2_0,
+            IslConstraintImpl::Ieee754Float(interchange_format),
+        )
     }
 }
 

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -749,7 +749,7 @@ impl IslConstraintImpl {
                 }
                 if !value.annotations().is_empty() {
                     return invalid_schema_error(
-                        "`ieee_754_float` constraint must be one of binary16, binary32, binary64",
+                        "`ieee_754_float` argument must not have annotations",
                     );
                 }
                 let string_value =
@@ -758,9 +758,7 @@ impl IslConstraintImpl {
                         .map(|s| s.text().unwrap())
                         .ok_or_else(|| {
                             invalid_schema_error_raw(format!(
-                                "expected ieee754_float to contain a symbol but found: {}",
-                                value.ion_type()
-                            ))
+                                "expected ieee754_float to be one of 'binary16', 'binary32', or 'binary64', but it was: {value}"))
                         })?;
                 Ok(IslConstraintImpl::Ieee754Float(string_value.try_into()?))
             }

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -258,6 +258,7 @@ mod isl_tests {
     use crate::isl::isl_type::v_1_0::*;
     use crate::isl::isl_type::{IslType, IslTypeImpl};
     use crate::isl::isl_type_reference::v_1_0::*;
+    use crate::isl::util::Ieee754InterchangeFormat;
     use crate::isl::util::TimestampPrecision;
     use crate::isl::IslVersion;
     use crate::isl::*;
@@ -552,7 +553,13 @@ mod isl_tests {
         anonymous_type(
             [timestamp_offset(vec!["+00:00".try_into().unwrap()])]
         )
-    )
+    ),
+    case::ieee754_float_constraint(
+        load_anonymous_type_v2_0(r#" // For a schema with ieee754_float constraint as below:
+                            { ieee754_float: binary16 }
+                        "#),
+        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::ieee754_float(Ieee754InterchangeFormat::Binary16)])
+    ),
     )]
     fn owned_struct_to_isl_type(isl_type1: IslType, isl_type2: IslType) {
         // assert if both the IslType are same in terms of constraints and name

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -297,3 +297,17 @@ impl TryFrom<&str> for Ieee754InterchangeFormat {
         })
     }
 }
+
+impl Display for Ieee754InterchangeFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Ieee754InterchangeFormat::Binary16 => "binary16",
+                Ieee754InterchangeFormat::Binary32 => "binary32",
+                Ieee754InterchangeFormat::Binary64 => "binary64",
+            }
+        )
+    }
+}

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -284,17 +284,17 @@ impl TryFrom<&str> for Ieee754InterchangeFormat {
     type Error = IonSchemaError;
     fn try_from(string_value: &str) -> Result<Self, Self::Error> {
         use Ieee754InterchangeFormat::*;
-        Ok(match string_value {
-            "binary16" => Binary16,
-            "binary32" => Binary32,
-            "binary64" => Binary64,
+        match string_value {
+            "binary16" => Ok(Binary16),
+            "binary32" => Ok(Binary32),
+            "binary64" => Ok(Binary64),
             _ => {
                 return invalid_schema_error(format!(
                     "unrecognized `ieee754_float` value {}",
                     &string_value
                 ))
             }
-        })
+        }
     }
 }
 

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -272,3 +272,28 @@ impl Display for TimestampOffset {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ieee754InterchangeFormat {
+    Binary16,
+    Binary32,
+    Binary64,
+}
+
+impl TryFrom<&str> for Ieee754InterchangeFormat {
+    type Error = IonSchemaError;
+    fn try_from(string_value: &str) -> Result<Self, Self::Error> {
+        use Ieee754InterchangeFormat::*;
+        Ok(match string_value {
+            "binary16" => Binary16,
+            "binary32" => Binary32,
+            "binary64" => Binary64,
+            _ => {
+                return invalid_schema_error(format!(
+                    "unrecognized `ieee754_float` value {}",
+                    &string_value
+                ))
+            }
+        })
+    }
+}

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -288,12 +288,10 @@ impl TryFrom<&str> for Ieee754InterchangeFormat {
             "binary16" => Ok(Binary16),
             "binary32" => Ok(Binary32),
             "binary64" => Ok(Binary64),
-            _ => {
-                return invalid_schema_error(format!(
-                    "unrecognized `ieee754_float` value {}",
-                    &string_value
-                ))
-            }
+            _ => invalid_schema_error(format!(
+                "unrecognized `ieee754_float` value {}",
+                &string_value
+            )),
         }
     }
 }

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -306,7 +306,14 @@ mod schema_tests {
                         type:: { name: timestamp_offset_type, timestamp_offset: ["+07:00", "+08:00", "+08:45", "+09:00"] }
                      "#).into_iter(),
         1 // this includes named type regex_type
-    )
+    ),
+    case::ieee754_float_constraint(
+        load(r#" // For a schema with ieee754_float constraint as below:
+                        $ion_schema_2_0
+                        type:: { name: ieee754_float_type, iee4754_float: binary16 }
+                     "#).into_iter(),
+        1 // this includes named type ieee754_float_type
+    ),
     )]
     fn owned_elements_to_schema<I: Iterator<Item = Element>>(
         owned_elements: I,
@@ -1232,6 +1239,31 @@ mod schema_tests {
                             type::{ name: timestamp_offset_type, timestamp_offset: ["-00:00", "+00:00", "+01:00", "-01:01"] }
                     "#),
             "timestamp_offset_type"
+        ),
+        case::ieee754_float_constraint(
+            load(r#"
+                      1e0
+                      -1e0
+                      65504e0
+                      -65504e0
+                      nan
+                      +inf
+                      -inf
+                    "#),
+            load(r#"
+                      null.float
+                      5
+                      5d0
+                      (5e0)
+                      [5e0]
+                      65505e0
+                      -65505e0
+                    "#),
+            load_schema_from_text(r#" // For a schema with timestamp precision constraint as below:
+                            $ion_schema_2_0
+                            type::{ name: ieee754_float_type, ieee754_float: binary16 }
+                    "#),
+            "ieee754_float_type"
         ),
     )]
     fn type_validation(

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -605,6 +605,7 @@ mod type_definition_tests {
     use crate::isl::isl_type::v_1_0::*;
     use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::v_1_0::*;
+    use crate::isl::util::Ieee754InterchangeFormat;
     use crate::isl::*;
     use crate::system::PendingTypes;
     use ion_rs::Decimal;
@@ -848,7 +849,14 @@ mod type_definition_tests {
     TypeDefinitionKind::anonymous([Constraint::timestamp_offset(vec!["-00:00".try_into().unwrap()]),
             Constraint::type_constraint(34)
         ])
-    )
+    ),
+    case::ieee754_float_constraint(
+        /* For a schema with ieee754_float constraint as below:
+            { ieee754_float: binary16 }
+        */
+        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::ieee754_float(Ieee754InterchangeFormat::Binary16)]),
+        TypeDefinitionKind::anonymous([Constraint::ieee754_float(Ieee754InterchangeFormat::Binary16), Constraint::type_constraint(34)])
+    ),
     )]
     fn isl_type_to_type_definition(isl_type: IslType, type_def: TypeDefinitionKind) {
         // assert if both the TypeDefinitionKind are same in terms of constraints and name

--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -67,7 +67,8 @@ pub enum ViolationCode {
     FieldNamesMismatched,  // this is used for mismatched field names in a struct
     FieldNamesNotDistinct, // this is used for field names that are not distinct in a struct
     FieldsNotMatched,
-    InvalidLength, // this is ued for any length related constraints (e.g. container_length, byte_length, codepoint_length)
+    InvalidIeee754Float, // this is used for ieee754_float constraint
+    InvalidLength, // this is used for any length related constraints (e.g. container_length, byte_length, codepoint_length)
     InvalidNull,   // if the value is a null for type references that doesn't allow null
     InvalidOpenContent, // if a container contains open content when `content: closed` is specified
     InvalidValue,  // this is used for valid_values constraint
@@ -95,6 +96,7 @@ impl fmt::Display for ViolationCode {
                 ViolationCode::FieldNamesMismatched => "field_names_mismatched",
                 ViolationCode::FieldNamesNotDistinct => "field_names_not_distinct",
                 ViolationCode::FieldsNotMatched => "fields_not_matched",
+                ViolationCode::InvalidIeee754Float => "invalid_ieee754_float",
                 ViolationCode::InvalidLength => "invalid_length",
                 ViolationCode::InvalidNull => "invalid_null",
                 ViolationCode::InvalidOpenContent => "invalid_open_content",


### PR DESCRIPTION
### Issue #160:

### Description of changes:
This PR works on adding struct fields related constraint field_names and closed:: modifier for fields constraint.

### List of changes:

-  adds changes for `ieee754_float` constraint implementation
-  adds `Ieee754Float` enum variants for `IslConstraintImpl` and `Constraint`
-  adds Ieee754FloatConstraint implementations
-  adds validation logic for `ieee754_float`
- adds dependency to [`half`](https://crates.io/crates/half/) crate for binary16 conversion 
-  adds unit tests for `ieee754_float`

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
