### PR TITLE
adds implementation of annotations constraint ISL 2.0

### DIFF
--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -2,14 +2,12 @@ use ion_schema_tests_runner::ion_schema_tests;
 
 ion_schema_tests!(
     root = "ion-schema-tests/ion_schema_2_0/",
-    // Support for ISL 2.0 is not implemented yet, so all tests are ignored.
+    // Support for ISL 2.0 is not implemented yet, so some tests are ignored.
     ignored(
         "open_content",
         "imports",
         "schema::*",
         "constraints::all_of",
-        "constraints::annotations_simplified",
-        "constraints::annotations_standard",
         "constraints::any_of",
         "constraints::byte_length",
         "constraints::codepoint_length",

--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -2,7 +2,7 @@ use ion_schema_tests_runner::ion_schema_tests;
 
 ion_schema_tests!(
     root = "ion-schema-tests/ion_schema_2_0/",
-    // Support for ISL 2.0 is not implemented yet, so some tests are ignored.
+    // Support for ISL 2.0 is not completely implemented yet, so some tests are ignored.
     ignored(
         "open_content",
         "imports",

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -1,5 +1,5 @@
 use crate::ion_path::{IonPath, IonPathElement};
-use crate::isl::isl_constraint::{IslConstraintImpl, IslRegexConstraint};
+use crate::isl::isl_constraint::{IslAnnotationsConstraint, IslConstraintImpl, IslRegexConstraint};
 use crate::isl::isl_range::{Range, RangeImpl};
 use crate::isl::isl_type_reference::{IslTypeRefImpl, NullabilityModifier};
 use crate::isl::util::{
@@ -48,6 +48,7 @@ pub trait ConstraintValidator {
 pub enum Constraint {
     AllOf(AllOfConstraint),
     Annotations(AnnotationsConstraint),
+    Annotations2_0(AnnotationsConstraint2_0),
     AnyOf(AnyOfConstraint),
     ByteLength(ByteLengthConstraint),
     CodepointLength(CodepointLengthConstraint),
@@ -193,6 +194,14 @@ impl Constraint {
         ))
     }
 
+    /// Creates a [Constraint::Annotations] using [TypeId] specified inside it
+    pub fn annotations_v2_0(id: TypeId) -> Constraint {
+        Constraint::Annotations2_0(AnnotationsConstraint2_0::new(TypeReference::new(
+            id,
+            NullabilityModifier::Nothing,
+        )))
+    }
+
     /// Creates a [Constraint::Precision] from a [Range] specifying a precision range.
     pub fn precision(precision: RangeImpl<usize>) -> Constraint {
         Constraint::Precision(PrecisionConstraint::new(Range::NonNegativeInteger(
@@ -322,13 +331,42 @@ impl Constraint {
                 )?;
                 Ok(Constraint::AllOf(AllOfConstraint::new(type_references)))
             }
-            IslConstraintImpl::Annotations(isl_annotations) => {
-                Ok(Constraint::Annotations(AnnotationsConstraint::new(
-                    isl_annotations.is_closed,
-                    isl_annotations.is_ordered,
-                    isl_annotations.annotations.to_owned(),
-                )))
-            }
+            IslConstraintImpl::Annotations(isl_annotations) => match isl_annotations {
+                IslAnnotationsConstraint::SimpleAnnotations(simple_annotations) => {
+                    match isl_version {
+                        IslVersion::V1_0 => {
+                            Ok(Constraint::Annotations(AnnotationsConstraint::new(
+                                simple_annotations.is_closed,
+                                simple_annotations.is_ordered,
+                                simple_annotations.annotations.to_owned(),
+                            )))
+                        }
+                        IslVersion::V2_0 => {
+                            let type_ref = IslTypeRefImpl::resolve_type_reference(
+                                IslVersion::V2_0,
+                                &simple_annotations.convert_to_type_reference()?,
+                                type_store,
+                                pending_types,
+                            )?;
+
+                            Ok(Constraint::Annotations2_0(AnnotationsConstraint2_0::new(
+                                type_ref,
+                            )))
+                        }
+                    }
+                }
+                IslAnnotationsConstraint::StandardAnnotations(isl_type_ref) => {
+                    let type_ref = IslTypeRefImpl::resolve_type_reference(
+                        isl_version,
+                        isl_type_ref,
+                        type_store,
+                        pending_types,
+                    )?;
+                    Ok(Constraint::Annotations2_0(AnnotationsConstraint2_0::new(
+                        type_ref,
+                    )))
+                }
+            },
             IslConstraintImpl::AnyOf(isl_type_references) => {
                 let type_references = Constraint::resolve_type_references(
                     isl_version,
@@ -479,6 +517,9 @@ impl Constraint {
         match self {
             Constraint::AllOf(all_of) => all_of.validate(value, type_store, ion_path),
             Constraint::Annotations(annotations) => {
+                annotations.validate(value, type_store, ion_path)
+            }
+            Constraint::Annotations2_0(annotations) => {
                 annotations.validate(value, type_store, ion_path)
             }
             Constraint::AnyOf(any_of) => any_of.validate(value, type_store, ion_path),
@@ -1501,6 +1542,71 @@ impl ConstraintValidator for ElementConstraint {
             ));
         }
         Ok(())
+    }
+}
+
+/// Implements the `annotations` constraint
+/// [annotations]: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#annotations
+// This is used for both simple and standard syntax of annotations constraint.
+// The simple syntax will be converted to a standard syntax for removing complexity in the validation logic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnnotationsConstraint2_0 {
+    type_ref: TypeReference,
+}
+
+impl AnnotationsConstraint2_0 {
+    pub fn new(type_ref: TypeReference) -> Self {
+        Self { type_ref }
+    }
+}
+
+impl ConstraintValidator for AnnotationsConstraint2_0 {
+    fn validate(
+        &self,
+        value: &IonSchemaElement,
+        type_store: &TypeStore,
+        ion_path: &mut IonPath,
+    ) -> ValidationResult {
+        let mut violations: Vec<Violation> = vec![];
+
+        match value {
+            IonSchemaElement::SingleElement(element) => {
+                let mut sequence_builder = Element::sequence_builder();
+                for annotation in element.annotations().iter() {
+                    sequence_builder =
+                        sequence_builder.push(Element::symbol(annotation.to_owned()));
+                }
+
+                let schema_element: IonSchemaElement =
+                    (&Element::from(sequence_builder.build_list())).into();
+                if let Err(violation) =
+                    self.type_ref
+                        .validate(&schema_element, type_store, ion_path)
+                {
+                    violations.push(violation);
+                }
+
+                if !violations.is_empty() {
+                    return Err(Violation::with_violations(
+                        "annotations",
+                        ViolationCode::AnnotationMismatched,
+                        "one or more annotations don't satisfy annotations constraint",
+                        ion_path,
+                        violations,
+                    ));
+                }
+                Ok(())
+            }
+            IonSchemaElement::Document(document) => {
+                // document type can not have annotations
+                Err(Violation::new(
+                    "annotations",
+                    ViolationCode::AnnotationMismatched,
+                    "annotations constraint is not applicable for document type",
+                    ion_path,
+                ))
+            }
+        }
     }
 }
 

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -440,7 +440,7 @@ pub mod v_2_0 {
     }
 
     /// Creates an `annotations` constraint using a list of valid annotations and specify whether annotations are required or closed or both.
-    pub fn simple_annotations<'a, A: IntoIterator<Item = Element>>(
+    pub fn simple_annotations<A: IntoIterator<Item = Element>>(
         is_required: bool,
         is_closed: bool,
         annotations: A,

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -440,7 +440,7 @@ pub mod v_2_0 {
     }
 
     /// Creates an `annotations` constraint using a list of valid annotations and specify whether annotations are required or closed or both.
-    pub fn simple_annotations<A: IntoIterator<Item = Element>>(
+    pub fn annotations_simplified<A: IntoIterator<Item = Element>>(
         is_required: bool,
         is_closed: bool,
         annotations: A,
@@ -463,7 +463,7 @@ pub mod v_2_0 {
     }
 
     /// Creates an `annotations` constraint using an [IslTypeRef].
-    pub fn standard_annotations(isl_type: IslTypeRef) -> IslConstraint {
+    pub fn annotations(isl_type: IslTypeRef) -> IslConstraint {
         IslConstraint::new(
             IslVersion::V2_0,
             IslConstraintImpl::Annotations(IslAnnotationsConstraint::StandardAnnotations(

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -487,7 +487,7 @@ mod isl_tests {
         load_anonymous_type_v2_0(r#" // For a schema with annotations constraint as below:
                             { annotations: { container_length: 1 } }
                         "#),
-    isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::standard_annotations(isl_type_reference::v_2_0::anonymous_type_ref([isl_constraint::v_2_0::container_length(1.into())]))])
+    isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::annotations(isl_type_reference::v_2_0::anonymous_type_ref([isl_constraint::v_2_0::container_length(1.into())]))])
     ),
     case::precision_constraint(
         load_anonymous_type(r#" // For a schema with precision constraint as below:

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -483,6 +483,12 @@ mod isl_tests {
                     "#),
         anonymous_type([annotations(vec!["closed"], vec![Symbol::from("red").into(), Symbol::from("blue").into(), Symbol::from("green").into()])])
     ),
+    case::standard_syantx_annotations_constraint(
+        load_anonymous_type_v2_0(r#" // For a schema with annotations constraint as below:
+                            { annotations: { container_length: 1 } }
+                        "#),
+    isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::standard_annotations(isl_type_reference::v_2_0::anonymous_type_ref([isl_constraint::v_2_0::container_length(1.into())]))])
+    ),
     case::precision_constraint(
         load_anonymous_type(r#" // For a schema with precision constraint as below:
                         { precision: 2 }

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -1265,6 +1265,24 @@ mod schema_tests {
                     "#),
             "ieee754_float_type"
         ),
+        case::annotations_constraint_with_standard_syntax(
+            load(r#"
+                   a::0
+                   b::1
+                   c::2
+                "#),
+            load(r#"
+                   0
+                   $a::1
+                   _c::2
+                   ''::3
+                "#),
+            load_schema_from_text(r#" // For a schema with annotations constraint as below:
+                            $ion_schema_2_0
+                            type::{ name: standard_annotations_type, annotations: { element: { regex: "^[a-z]$" }, container_length: 1 } }
+                    "#),
+            "standard_annotations_type"
+        )
     )]
     fn type_validation(
         valid_values: Vec<Element>,

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -765,7 +765,7 @@ mod type_definition_tests {
         /* For a schema with annotations constraint as below:
             { annotations: { container_length: 1 } }
         */
-        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::standard_annotations(isl_type_reference::v_2_0::anonymous_type_ref([isl_constraint::v_2_0::container_length(1.into())]))]),
+        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::annotations(isl_type_reference::v_2_0::anonymous_type_ref([isl_constraint::v_2_0::container_length(1.into())]))]),
         TypeDefinitionKind::anonymous([Constraint::annotations_v2_0(36), Constraint::type_constraint(34)])
     ),
     case::precision_constraint(

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -761,6 +761,13 @@ mod type_definition_tests {
         anonymous_type([annotations(vec!["closed"], vec![Symbol::from("red").into(), Symbol::from("blue").into(), Symbol::from("green").into()])]),
     TypeDefinitionKind::anonymous([Constraint::annotations(vec!["closed"], vec![Symbol::from("red").into(), Symbol::from("blue").into(), Symbol::from("green").into()]), Constraint::type_constraint(34)])
     ),
+    case::annotations_v2_0_constraint(
+        /* For a schema with annotations constraint as below:
+            { annotations: { container_length: 1 } }
+        */
+        isl_type::v_2_0::anonymous_type([isl_constraint::v_2_0::standard_annotations(isl_type_reference::v_2_0::anonymous_type_ref([isl_constraint::v_2_0::container_length(1.into())]))]),
+        TypeDefinitionKind::anonymous([Constraint::annotations_v2_0(36), Constraint::type_constraint(34)])
+    ),
     case::precision_constraint(
         /* For a schema with precision constraint as below:
             { precision: 3 }

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -560,7 +560,12 @@ impl TypeValidator for TypeDefinitionImpl {
     ) -> ValidationResult {
         let mut violations: Vec<Violation> = vec![];
         let type_name = match self.name() {
-            None => format!("{}", self.isl_type_struct.as_ref().unwrap()),
+            None => match self.isl_type_struct.as_ref() {
+                None => "".to_owned(),
+                Some(anonymous_struct) => {
+                    format!("{anonymous_struct}")
+                }
+            },
             Some(name) => name.to_owned(),
         };
         for constraint in self.constraints() {


### PR DESCRIPTION
### Description of changes:
This PR adds implementation of annotations constraint ISL 2.0.

### Grammar:
```
<ANNOTATIONS> ::= annotations: <ANNOTATIONS_MODIFIER>... [ <SYMBOL>... ]
                | annotations: <TYPE_ARGUMENT>

<ANNOTATIONS_MODIFIER> ::= required::
                         | closed::

```

### Ion schema specification:
https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#annotations

### List of changes:
* adds support for standard and simple syntax for annotations constraint as per ISL 2.0
* adds enum `IslAnnotationsConstraint` which holds two variants for
standard and simple syntax of annotations constraint
* adds `Anotations2_0Constraint` to handle ISL 2.0 related annotations
validation based on a type reference
* adds unit tests for `annotations` constraint ISL 2.0
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
