### PR TITLE
adds implementation of regex constraint ISL 2.0

### DIFF
--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -17,8 +17,7 @@ ion_schema_tests!(
         "constraints::one_of",
         "constraints::ordered_elements",
         "constraints::precision",
-        "constraints::regex",
-        "constraints::regex-invalid",
+        "constraints::regex::value_should_be_invalid_for_type_regex_unescaped_newline__2_", // https://github.com/amazon-ion/ion-rust/issues/399
         "constraints::timestamp_offset",
         "constraints::timestamp_precision",
         "constraints::type",

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -892,12 +892,28 @@ impl IslConstraintImpl {
                 let case_insensitive = value.annotations().contains("i");
                 let multi_line = value.annotations().contains("m");
 
+                if value
+                    .annotations()
+                    .iter()
+                    .any(|a| a.text().unwrap() != "i" && a.text().unwrap() != "m")
+                {
+                    return invalid_schema_error(
+                        "regex constraint must only contain 'i' or 'm' annotation",
+                    );
+                }
+
                 let expression = value.as_string().ok_or_else(|| {
                     invalid_schema_error_raw(format!(
                         "expected regex to contain a string expression but found: {}",
                         value.ion_type()
                     ))
                 })?;
+
+                if expression.is_empty() {
+                    return invalid_schema_error(
+                        "regex constraint must contain a non empty expression",
+                    );
+                }
 
                 Ok(IslConstraintImpl::Regex(IslRegexConstraint::new(
                     case_insensitive,

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -1221,6 +1221,31 @@ mod schema_tests {
                     "#),
             "regex_type"
         ),
+        case::regex_v2_0_constraint(
+            load(r#"
+                        "/"
+                        ":"
+                        "@"
+                        "["
+                        "`"
+                        "{"
+                        " "
+                    "#),
+            load(r#"
+                        "a"
+                        "A"
+                        "z"
+                        "Z"
+                        "0"
+                        "9"
+                        "_"
+                    "#),
+            load_schema_from_text(r#" // For a schema with regex constraint as below:
+                            $ion_schema_2_0
+                            type::{ name: regex_type, regex: "\\W" }
+                    "#),
+            "regex_type"
+        ),
         case::timestamp_offset_constraint(
             load(r#"
                       2000T

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -846,7 +846,8 @@ mod type_definition_tests {
             Constraint::regex(
                 false, // case insensitive
                 false, // multiline
-                "[abc]".to_string()
+                "[abc]".to_string(),
+                IslVersion::V1_0
             ).unwrap(),
             Constraint::type_constraint(34)
         ])


### PR DESCRIPTION
### Issue #161
### Description of changes:
This PR works on adding implementation of `regex` constraint as per ISL 2.0.

### List of changes:
* adds changes to support character classes in regex ISL 2.0 
* adds changes to return error when regex has annotations other than "i" and "m". 
* adds changes to return error for empty regex 

### Tests:
added unit tests for `regex` implementation.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
