### PR TITLE
adds changes for timestamp ranges ISL 2.0

### DIFF
--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -22,7 +22,10 @@ ion_schema_tests!(
         "constraints::timestamp_precision",
         "constraints::type",
         "constraints::utf8_byte_length",
-        "constraints::valid_values",
-        "constraints::valid_values-ranges"
+        // following tests are related to: https://github.com/amazon-ion/ion-rust/pull/553
+        "constraints::valid_values_ranges::value_should_be_valid_for_type_valid_values_range_timestamp_known_offset__12_",
+        "constraints::valid_values_ranges::value_should_be_valid_for_type_valid_values_range_timestamp_known_offset__13_",
+        "constraints::valid_values_ranges::value_should_be_valid_for_type_valid_values_range_timestamp_unknown_offset__12_",
+        "constraints::valid_values_ranges::value_should_be_valid_for_type_valid_values_range_timestamp_unknown_offset__13_"
     )
 );

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -577,6 +577,7 @@ mod isl_tests {
         Range::from_ion_element(
             &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             RangeType::Any,
+            IslVersion::V1_0,
         )
     }
 
@@ -585,6 +586,7 @@ mod isl_tests {
         Range::from_ion_element(
             &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             RangeType::TimestampPrecision,
+            IslVersion::V1_0,
         )
     }
 
@@ -593,6 +595,7 @@ mod isl_tests {
         Range::from_ion_element(
             &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             RangeType::NumberOrTimestamp,
+            IslVersion::V1_0,
         )
     }
 

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -573,20 +573,11 @@ mod isl_tests {
     }
 
     // helper function to create a range
-    fn load_range(text: &str) -> IonSchemaResult<Range> {
+    fn load_range(text: &str, isl_version: IslVersion) -> IonSchemaResult<Range> {
         Range::from_ion_element(
             &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
             RangeType::Any,
-            IslVersion::V1_0,
-        )
-    }
-
-    // helper function to create a range
-    fn load_range_v2_0(text: &str) -> IonSchemaResult<Range> {
-        Range::from_ion_element(
-            &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
-            RangeType::Any,
-            IslVersion::V2_0,
+            isl_version,
         )
     }
 
@@ -620,7 +611,8 @@ mod isl_tests {
             load_range(
                 r#"
                     range::[min, 5]
-                "#
+                "#,
+                IslVersion::V1_0
             ).unwrap(),
             IntegerRange::new(
                 RangeBoundaryValue::Min,
@@ -631,7 +623,8 @@ mod isl_tests {
             load_range(
                 r#"
                     range::[2e1, 5e1]
-                "#
+                "#,
+                IslVersion::V1_0
             ).unwrap(),
             FloatRange::new(
                 2e1,
@@ -642,7 +635,8 @@ mod isl_tests {
             load_range(
                 r#"
                     range::[20.4, 50.5]
-                "#
+                "#,
+                IslVersion::V1_0
             ).unwrap(),
             DecimalRange::new(
                 Decimal::new(204, -1),
@@ -650,10 +644,11 @@ mod isl_tests {
             ).unwrap()
         ),
         case::range_with_timestamp(
-            load_range_v2_0(
+            load_range(
                 r#"
                     range::[2020-01-01T, 2021-01-01T]
-                "#
+                "#,
+                IslVersion::V2_0
             ).unwrap(),
             TimestampRange::new(
                 Timestamp::with_year(2020).with_month(1).with_day(1).build().unwrap(),
@@ -693,27 +688,32 @@ mod isl_tests {
         case::range_with_min_max(load_range(
             r#"
                 range::[min, max]
-            "#
+            "#,
+            IslVersion::V1_0
         )),
         case::range_with_max_lower_bound(load_range(
             r#"
                 range::[max, 5]
-            "#
+            "#,
+            IslVersion::V1_0
         )),
         case::range_with_min_upper_bound(load_range(
             r#"
                 range::[5, min]
-            "#
+            "#,
+            IslVersion::V1_0
         )),
         case::range_with_mismatched_bounds(load_range(
             r#"
                 range::[5, 7.834]
-            "#
+            "#,
+            IslVersion::V1_0
         )),
         case::range_with_lower_bound_greater_than_upper_bound(load_range(
             r#"
                 range::[10, 5]
-            "#
+            "#,
+            IslVersion::V1_0
         ))
     )]
     fn invalid_ranges(range: IonSchemaResult<Range>) {
@@ -729,7 +729,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[0, 10]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[5, 0, 10]),
             elements(&[-5, 11])
@@ -738,7 +739,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[min, 10]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[5, -5, 0]),
             elements(&[11])
@@ -747,7 +749,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[0, max]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[5, 0, 11]),
             elements(&[-5])
@@ -756,7 +759,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[exclusive::0, exclusive::10]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[5, 9]),
             elements(&[-5, 0, 10])
@@ -765,7 +769,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[0.0, 10.0]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[Decimal::new(55,-1), Decimal::new(0, 0), Decimal::new(100, -1)]),
             elements(&[Decimal::new(-55, -1), Decimal::new(115, -1)])
@@ -774,7 +779,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[min, 10.0]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[Decimal::new(50, -1), Decimal::new(-55, -1), Decimal::new(0, 0)]),
             elements(&[Decimal::new(115, -1)])
@@ -783,7 +789,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[0.0, max]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[Decimal::new(55, -1), Decimal::new(115, -1)]),
             elements(&[Decimal::new(-55, -1)])
@@ -792,7 +799,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[exclusive::1.0, exclusive::10.0]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[Decimal::new(50, -1), Decimal::new(95, -1)]),
             elements(&[Decimal::new(-55, -1), Decimal::new(10, -1), Decimal::new(100, -1)])
@@ -801,7 +809,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[1e2, 5e2]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[2e2, 1e2, 5e2]),
             elements(&[-1e2,1e1, 6e2, f64::NAN, 0e0, -0e0])
@@ -810,7 +819,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[min, 2e5]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[f64::NEG_INFINITY, 2.2250738585072014e-308, 2e5, -2e5, 0e0, -0e0]),
             elements(&[3e5, f64::NAN])
@@ -819,7 +829,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[1e5, max]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[1e5, 5e5, 1e6, 1.7976931348623157e308, f64::INFINITY]),
             elements(&[-5e5, 1e2, f64::NAN])
@@ -828,7 +839,8 @@ mod isl_tests {
             load_range(
             r#"
                 range::[exclusive::1e2, exclusive::5e2]
-            "#
+            "#,
+            IslVersion::V1_0
             ),
             elements(&[2e2]),
             elements(&[-1e2 ,1e1, 6e2, 1e2, 5e2, f64::NAN])

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -581,6 +581,15 @@ mod isl_tests {
         )
     }
 
+    // helper function to create a range
+    fn load_range_v2_0(text: &str) -> IonSchemaResult<Range> {
+        Range::from_ion_element(
+            &Element::read_one(text.as_bytes()).expect("parsing failed unexpectedly"),
+            RangeType::Any,
+            IslVersion::V2_0,
+        )
+    }
+
     // helper function to create a timestamp precision range
     fn load_timestamp_precision_range(text: &str) -> IonSchemaResult<Range> {
         Range::from_ion_element(
@@ -641,7 +650,7 @@ mod isl_tests {
             ).unwrap()
         ),
         case::range_with_timestamp(
-            load_range(
+            load_range_v2_0(
                 r#"
                     range::[2020-01-01T, 2021-01-01T]
                 "#

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -1,5 +1,6 @@
 use crate::isl::isl_range::{Range, RangeType};
-use crate::result::{invalid_schema_error, IonSchemaError};
+use crate::isl::IslVersion;
+use crate::result::{invalid_schema_error, IonSchemaError, IonSchemaResult};
 use ion_rs::element::Element;
 use ion_rs::types::timestamp::Precision;
 use ion_rs::{Symbol, Timestamp};
@@ -169,14 +170,13 @@ pub enum ValidValue {
     Element(Element),
 }
 
-impl TryFrom<&Element> for ValidValue {
-    type Error = IonSchemaError;
-
-    fn try_from(value: &Element) -> Result<Self, Self::Error> {
+impl ValidValue {
+    pub fn from_ion_element(value: &Element, isl_version: IslVersion) -> IonSchemaResult<Self> {
         if value.annotations().contains("range") {
             Ok(ValidValue::Range(Range::from_ion_element(
                 value,
                 RangeType::NumberOrTimestamp,
+                isl_version,
             )?))
         } else if value
             .annotations()

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -801,7 +801,7 @@ mod type_definition_tests {
             { valid_values: [2, 3.5, 5e7, "hello", hi] }
         */
         anonymous_type([valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), Symbol::from("hi").into()]).unwrap()]),
-    TypeDefinitionKind::anonymous([Constraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), Symbol::from("hi").into()]).unwrap(), Constraint::type_constraint(34)])
+    TypeDefinitionKind::anonymous([Constraint::valid_values_with_values(vec![2.into(), Decimal::new(35, -1).into(), 5e7.into(), "hello".to_owned().into(), Symbol::from("hi").into()], IslVersion::V1_0).unwrap(), Constraint::type_constraint(34)])
     ),
     case::valid_values_with_range_constraint(
         /* For a schema with valid_values constraint as below:


### PR DESCRIPTION
### Issue #163

### Description of changes:
This PR adds changes for timestamp ranges as per ISL 2.0.

### List of changes:
* adds changes to allow unknown offsets on timestamp ranges for ISL 2.0
* adds changes to pass isl_version for `ValidValues` constraint
* adds changes to check for `exclusive` annotation on min/max range boundary value
* adds unit tests

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
