### PR TITLE
adds implementation of `IslVariablyOccurringTypeRef`

### DIFF
--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -820,8 +820,7 @@ impl OrderedElementsConstraint {
             .iter()
             .map(|t|
                 // resolve type references and create variably occurring type reference with occurs range
-                t.resolve_type_reference("ordered_elements", isl_version, type_store, pending_types)
-                )
+                t.resolve_type_reference(isl_version, type_store, pending_types))
             .collect::<IonSchemaResult<Vec<VariablyOccurringTypeRef>>>()?;
 
         Ok(OrderedElementsConstraint::new(resolved_types))
@@ -1013,7 +1012,7 @@ impl FieldsConstraint {
             .map(|(f, t)| {
                 // resolve type references and create variably occurring type reference with occurs range
                 // default `occurs` field value for `fields` constraint is `occurs: optional` or `occurs: range::[0, 1]`
-                t.resolve_type_reference("fields", isl_version, type_store, pending_types)
+                t.resolve_type_reference(isl_version, type_store, pending_types)
                     .map(|variably_occurring_type_ref| (f.to_owned(), variably_occurring_type_ref))
             })
             .collect::<IonSchemaResult<HashMap<String, VariablyOccurringTypeRef>>>()?;

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -64,7 +64,6 @@ pub enum Constraint {
     Not(NotConstraint),
     OneOf(OneOfConstraint),
     OrderedElements(OrderedElementsConstraint),
-    Occurs,
     Precision(PrecisionConstraint),
     Regex(RegexConstraint),
     Scale(ScaleConstraint),
@@ -472,7 +471,6 @@ impl Constraint {
                 )?;
                 Ok(Constraint::Type(TypeConstraint::new(type_id)))
             }
-            IslConstraintImpl::Occurs(_) => Ok(Constraint::Occurs),
             IslConstraintImpl::OrderedElements(isl_type_references) => {
                 Ok(Constraint::OrderedElements(
                     OrderedElementsConstraint::resolve_from_isl_constraint(
@@ -565,13 +563,6 @@ impl Constraint {
             Constraint::OneOf(one_of) => one_of.validate(value, type_store, ion_path),
             Constraint::Type(type_constraint) => {
                 type_constraint.validate(value, type_store, ion_path)
-            }
-            Constraint::Occurs => {
-                // No op
-                // `occurs` does not work as a constraint by its own, it needs to be used with other constraints
-                // e.g. `ordered_elements`, `fields`, etc.
-                // the validation for occurs is done within these other constraints
-                Ok(())
             }
             Constraint::OrderedElements(ordered_elements) => {
                 ordered_elements.validate(value, type_store, ion_path)

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -869,6 +869,7 @@ impl IslConstraintImpl {
                     .elements()
                     .map(|e| {
                         IslVariablyOccurringTypeRef::from_ion_element(
+                            constraint_name,
                             isl_version,
                             e,
                             inline_imported_types,
@@ -1071,8 +1072,13 @@ impl IslConstraintImpl {
             .unwrap()
             .iter()
             .map(|(f, v)| {
-                IslVariablyOccurringTypeRef::from_ion_element(isl_version, v, inline_imported_types)
-                    .map(|t| (f.text().unwrap().to_owned(), t))
+                IslVariablyOccurringTypeRef::from_ion_element(
+                    "fields",
+                    isl_version,
+                    v,
+                    inline_imported_types,
+                )
+                .map(|t| (f.text().unwrap().to_owned(), t))
             })
             .collect::<IonSchemaResult<HashMap<String, IslVariablyOccurringTypeRef>>>()?;
 

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -80,7 +80,7 @@ pub mod v_1_0 {
     ) -> IslConstraint {
         IslConstraint::new(
             IslVersion::V1_0,
-            IslConstraintImpl::OrderedElements(isl_types.into().into_iter().map(|t| t).collect()),
+            IslConstraintImpl::OrderedElements(isl_types.into().into_iter().collect()),
         )
     }
 
@@ -323,7 +323,7 @@ pub mod v_2_0 {
     ) -> IslConstraint {
         IslConstraint::new(
             IslVersion::V2_0,
-            IslConstraintImpl::OrderedElements(isl_types.into().into_iter().map(|t| t).collect()),
+            IslConstraintImpl::OrderedElements(isl_types.into().into_iter().collect()),
         )
     }
 
@@ -852,9 +852,9 @@ impl IslConstraintImpl {
             }
             "ordered_elements" => {
                 if value.is_null() {
-                    return invalid_schema_error(format!(
-                        "ordered_elements constraint was a null instead of a list"
-                    ));
+                    return invalid_schema_error(
+                        "ordered_elements constraint was a null instead of a list",
+                    );
                 }
                 if value.ion_type() != IonType::List {
                     return invalid_schema_error(format!(

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -1,7 +1,7 @@
 use crate::isl;
 use crate::isl::isl_import::IslImportType;
 use crate::isl::isl_range::{Range, RangeType};
-use crate::isl::isl_type_reference::IslTypeRefImpl;
+use crate::isl::isl_type_reference::{IslTypeRefImpl, IslVariablyOccurringTypeRef};
 use crate::isl::util::{Annotation, Ieee754InterchangeFormat, TimestampOffset, ValidValue};
 use crate::isl::IslVersion;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
@@ -17,7 +17,7 @@ pub mod v_1_0 {
         IslSimpleAnnotationsConstraint, IslTimestampOffsetConstraint, IslValidValuesConstraint,
     };
     use crate::isl::isl_range::{IntegerRange, NonNegativeIntegerRange, Range, RangeImpl};
-    use crate::isl::isl_type_reference::IslTypeRef;
+    use crate::isl::isl_type_reference::{IslTypeRef, IslVariablyOccurringTypeRef};
     use crate::isl::util::{Annotation, TimestampOffset, TimestampPrecision, ValidValue};
     use crate::isl::IslVersion;
     use crate::result::IonSchemaResult;
@@ -74,17 +74,13 @@ pub mod v_1_0 {
         )
     }
 
-    /// Creates an `ordered_elements` constraint using the [IslTypeRef] referenced inside it
-    pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
+    /// Creates an `ordered_elements` constraint using the [IslVariablyOccurringTypeRef] referenced inside it
+    pub fn ordered_elements<A: Into<Vec<IslVariablyOccurringTypeRef>>>(
+        isl_types: A,
+    ) -> IslConstraint {
         IslConstraint::new(
             IslVersion::V1_0,
-            IslConstraintImpl::OrderedElements(
-                isl_types
-                    .into()
-                    .into_iter()
-                    .map(|t| t.type_reference)
-                    .collect(),
-            ),
+            IslConstraintImpl::OrderedElements(isl_types.into().into_iter().map(|t| t).collect()),
         )
     }
 
@@ -104,14 +100,14 @@ pub mod v_1_0 {
         )
     }
 
-    /// Creates a `fields` constraint using the field names and [IslTypeRef]s referenced inside it
+    /// Creates a `fields` constraint using the field names and [IslVariablyOccurringTypeRef]s referenced inside it
     pub fn fields<I>(fields: I) -> IslConstraint
     where
-        I: Iterator<Item = (String, IslTypeRef)>,
+        I: Iterator<Item = (String, IslVariablyOccurringTypeRef)>,
     {
         IslConstraint::new(
             IslVersion::V1_0,
-            IslConstraintImpl::Fields(fields.map(|(s, t)| (s, t.type_reference)).collect(), false),
+            IslConstraintImpl::Fields(fields.map(|(s, t)| (s, t)).collect(), false),
         )
     }
 
@@ -261,7 +257,7 @@ pub mod v_2_0 {
         IslConstraintImpl, IslTimestampOffsetConstraint, IslValidValuesConstraint,
     };
     use crate::isl::isl_range::{NonNegativeIntegerRange, Range, RangeImpl};
-    use crate::isl::isl_type_reference::IslTypeRef;
+    use crate::isl::isl_type_reference::{IslTypeRef, IslVariablyOccurringTypeRef};
     use crate::isl::util::{
         Annotation, Ieee754InterchangeFormat, TimestampOffset, TimestampPrecision, ValidValue,
     };
@@ -321,17 +317,13 @@ pub mod v_2_0 {
         )
     }
 
-    /// Creates an `ordered_elements` constraint using the [IslTypeRef] referenced inside it
-    pub fn ordered_elements<A: Into<Vec<IslTypeRef>>>(isl_types: A) -> IslConstraint {
+    /// Creates an `ordered_elements` constraint using the [IslVariablyOccurringTypeRef] referenced inside it
+    pub fn ordered_elements<A: Into<Vec<IslVariablyOccurringTypeRef>>>(
+        isl_types: A,
+    ) -> IslConstraint {
         IslConstraint::new(
             IslVersion::V2_0,
-            IslConstraintImpl::OrderedElements(
-                isl_types
-                    .into()
-                    .into_iter()
-                    .map(|t| t.type_reference)
-                    .collect(),
-            ),
+            IslConstraintImpl::OrderedElements(isl_types.into().into_iter().map(|t| t).collect()),
         )
     }
 
@@ -351,14 +343,14 @@ pub mod v_2_0 {
         )
     }
 
-    /// Creates a `fields` constraint using the field names and [IslTypeRef]s referenced inside it
+    /// Creates a `fields` constraint using the field names and [IslVariablyOccurringTypeRef]s referenced inside it
     pub fn fields<I>(fields: I) -> IslConstraint
     where
-        I: Iterator<Item = (String, IslTypeRef)>,
+        I: Iterator<Item = (String, IslVariablyOccurringTypeRef)>,
     {
         IslConstraint::new(
             IslVersion::V2_0,
-            IslConstraintImpl::Fields(fields.map(|(s, t)| (s, t.type_reference)).collect(), false),
+            IslConstraintImpl::Fields(fields.map(|(s, t)| (s, t)).collect(), false),
         )
     }
 
@@ -552,7 +544,7 @@ pub(crate) enum IslConstraintImpl {
     // Represents Fields(fields, content_closed)
     // For ISL 2.0 true/false is specified based on whether `closed::` annotation is present or not
     // For ISL 1.0 this will always be (fields, false) as it doesn't support `closed::` annotation on fields constraint
-    Fields(HashMap<String, IslTypeRefImpl>, bool),
+    Fields(HashMap<String, IslVariablyOccurringTypeRef>, bool),
     // Represents FieldNames(type_reference, expected_distinct).
     // For ISL 2.0 true/false is specified based on whether `distinct` annotation is present or not.
     // For ISL 1.0 which doesn't support `field_names` constraint this will be (type_reference, false).
@@ -561,7 +553,7 @@ pub(crate) enum IslConstraintImpl {
     Not(IslTypeRefImpl),
     Occurs(Range),
     OneOf(Vec<IslTypeRefImpl>),
-    OrderedElements(Vec<IslTypeRefImpl>),
+    OrderedElements(Vec<IslVariablyOccurringTypeRef>),
     Precision(Range),
     Regex(IslRegexConstraint),
     Scale(Range),
@@ -612,7 +604,6 @@ impl IslConstraintImpl {
                         isl_version,
                         value,
                         inline_imported_types,
-                        false,
                     )?;
 
                     Ok(IslConstraintImpl::Annotations(
@@ -698,12 +689,8 @@ impl IslConstraintImpl {
                 isl_version,
             )?)),
             "element" => {
-                let type_reference: IslTypeRefImpl = IslTypeRefImpl::from_ion_element(
-                    isl_version,
-                    value,
-                    inline_imported_types,
-                    false,
-                )?;
+                let type_reference: IslTypeRefImpl =
+                    IslTypeRefImpl::from_ion_element(isl_version, value, inline_imported_types)?;
                 match isl_version {
                     IslVersion::V1_0 => {
                         // for ISL 1.0 `distinct annotation on `element` constraint is not supported which is represented by `false` here
@@ -729,12 +716,8 @@ impl IslConstraintImpl {
                 }
             }
             "field_names" => {
-                let type_reference = IslTypeRefImpl::from_ion_element(
-                    isl_version,
-                    value,
-                    inline_imported_types,
-                    false,
-                )?;
+                let type_reference =
+                    IslTypeRefImpl::from_ion_element(isl_version, value, inline_imported_types)?;
                 match isl_version {
                     IslVersion::V1_0 => {
                         // for ISL 1.0 `field_names` constraint does not exist hence `field_names` will be considered as open content
@@ -764,7 +747,7 @@ impl IslConstraintImpl {
                 }
             }
             "fields" => {
-                let fields: HashMap<String, IslTypeRefImpl> =
+                let fields: HashMap<String, IslVariablyOccurringTypeRef> =
                     IslConstraintImpl::isl_fields_from_ion_element(
                         isl_version,
                         value,
@@ -821,21 +804,13 @@ impl IslConstraintImpl {
                 Ok(IslConstraintImpl::OneOf(types))
             }
             "not" => {
-                let type_reference: IslTypeRefImpl = IslTypeRefImpl::from_ion_element(
-                    isl_version,
-                    value,
-                    inline_imported_types,
-                    false,
-                )?;
+                let type_reference: IslTypeRefImpl =
+                    IslTypeRefImpl::from_ion_element(isl_version, value, inline_imported_types)?;
                 Ok(IslConstraintImpl::Not(type_reference))
             }
             "type" => {
-                let type_reference: IslTypeRefImpl = IslTypeRefImpl::from_ion_element(
-                    isl_version,
-                    value,
-                    inline_imported_types,
-                    false,
-                )?;
+                let type_reference: IslTypeRefImpl =
+                    IslTypeRefImpl::from_ion_element(isl_version, value, inline_imported_types)?;
                 Ok(IslConstraintImpl::Type(type_reference))
             }
             "occurs" => {
@@ -876,13 +851,30 @@ impl IslConstraintImpl {
                 Ok(IslConstraintImpl::Occurs(range))
             }
             "ordered_elements" => {
-                let types: Vec<IslTypeRefImpl> =
-                    IslConstraintImpl::isl_type_references_from_ion_element(
-                        isl_version,
-                        value,
-                        inline_imported_types,
-                        "ordered_elements",
-                    )?;
+                if value.is_null() {
+                    return invalid_schema_error(format!(
+                        "ordered_elements constraint was a null instead of a list"
+                    ));
+                }
+                if value.ion_type() != IonType::List {
+                    return invalid_schema_error(format!(
+                        "ordered_elements constraint was a {:?} instead of a list",
+                        value.ion_type()
+                    ));
+                }
+
+                let types: Vec<IslVariablyOccurringTypeRef> = value
+                    .as_sequence()
+                    .unwrap()
+                    .elements()
+                    .map(|e| {
+                        IslVariablyOccurringTypeRef::from_ion_element(
+                            isl_version,
+                            e,
+                            inline_imported_types,
+                        )
+                    })
+                    .collect::<IonSchemaResult<Vec<IslVariablyOccurringTypeRef>>>()?;
                 Ok(IslConstraintImpl::OrderedElements(types))
             }
             "precision" => Ok(IslConstraintImpl::Precision(Range::from_ion_element(
@@ -1049,19 +1041,11 @@ impl IslConstraintImpl {
                 value.ion_type()
             ));
         }
-        let allow_variably_occurring_type = constraint_name == "ordered_elements";
         value
             .as_sequence()
             .unwrap()
             .elements()
-            .map(|e| {
-                IslTypeRefImpl::from_ion_element(
-                    isl_version,
-                    e,
-                    inline_imported_types,
-                    allow_variably_occurring_type,
-                )
-            })
+            .map(|e| IslTypeRefImpl::from_ion_element(isl_version, e, inline_imported_types))
             .collect::<IonSchemaResult<Vec<IslTypeRefImpl>>>()
     }
 
@@ -1070,7 +1054,7 @@ impl IslConstraintImpl {
         isl_version: IslVersion,
         value: &Element,
         inline_imported_types: &mut Vec<IslImportType>,
-    ) -> IonSchemaResult<HashMap<String, IslTypeRefImpl>> {
+    ) -> IonSchemaResult<HashMap<String, IslVariablyOccurringTypeRef>> {
         if value.is_null() {
             return invalid_schema_error("fields constraint was a null instead of a struct");
         }
@@ -1087,10 +1071,10 @@ impl IslConstraintImpl {
             .unwrap()
             .iter()
             .map(|(f, v)| {
-                IslTypeRefImpl::from_ion_element(isl_version, v, inline_imported_types, true)
+                IslVariablyOccurringTypeRef::from_ion_element(isl_version, v, inline_imported_types)
                     .map(|t| (f.text().unwrap().to_owned(), t))
             })
-            .collect::<IonSchemaResult<HashMap<String, IslTypeRefImpl>>>()?;
+            .collect::<IonSchemaResult<HashMap<String, IslVariablyOccurringTypeRef>>>()?;
 
         // verify the map length with struct length to check for duplicates
         if fields_map.len() < value.as_struct().unwrap().len() {

--- a/ion-schema/src/isl/isl_type.rs
+++ b/ion-schema/src/isl/isl_type.rs
@@ -191,6 +191,7 @@ impl IslTypeImpl {
         for (field_name, value) in ion_struct.iter() {
             let constraint_name = match field_name.text() {
                 Some("name") => continue, // if the field_name is "name" then it's the type name not a constraint
+                Some("occurs") => continue, // if the field_name is "occurs" then skip it as it is handled elsewhere
                 Some(name) => name,
                 None => {
                     return Err(invalid_schema_error_raw(

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -219,7 +219,8 @@ impl IslTypeRefImpl {
                             "A type reference with an explicit `occurs` field can only be used for `fields` and `ordered_elements` constraint",
                             )
                         } else {
-                            // for ISL 1.0 ``occurs` field is a no op when used with constraints other than `fields` and `ordered_elements`
+                            // for ISL 1.0 `occurs` field is a no op when used with constraints other than `fields` and `ordered_elements`.
+                            // Although ISL 1.0 will treat this `occurs` field as no op it still has to serialize the `occurs` range to see if its a valid range.
                             IslVariablyOccurringTypeRef::occurs_from_ion_element(occurs_field, isl_version)?;
                         }
                     }

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -427,13 +427,13 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with ordered_elements constraint as below:
                     { ordered_elements: [  symbol, { type: int },  ] }
                 "#),
-        anonymous_type([ordered_elements([variably_occurring_type_ref(named_type_ref("symbol"), None), variably_occurring_type_ref(anonymous_type_ref([type_constraint(named_type_ref("int"))]), None)])])
+        anonymous_type([ordered_elements([variably_occurring_type_ref(named_type_ref("symbol"), Range::required()), variably_occurring_type_ref(anonymous_type_ref([type_constraint(named_type_ref("int"))]), Range::required())])])
     ),
     case::fields_constraint(
         load_anonymous_type(r#" // For a schema with fields constraint as below:
                     { fields: { name: string, id: int} }
                 "#),
-        anonymous_type([fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), None)), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), None))].into_iter())]),
+        anonymous_type([fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), Range::optional())), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), Range::optional()))].into_iter())]),
     ),
     case::field_names_constraint(
         load_anonymous_type_v2_0(r#" // For a schema with field_names constraint as below:

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -427,13 +427,13 @@ mod isl_tests {
         load_anonymous_type(r#" // For a schema with ordered_elements constraint as below:
                     { ordered_elements: [  symbol, { type: int },  ] }
                 "#),
-        anonymous_type([ordered_elements([named_type_ref("symbol"), anonymous_type_ref([type_constraint(named_type_ref("int"))])])])
+        anonymous_type([ordered_elements([variably_occurring_type_ref(named_type_ref("symbol"), None), variably_occurring_type_ref(anonymous_type_ref([type_constraint(named_type_ref("int"))]), None)])])
     ),
     case::fields_constraint(
         load_anonymous_type(r#" // For a schema with fields constraint as below:
                     { fields: { name: string, id: int} }
                 "#),
-        anonymous_type([fields(vec![("name".to_owned(), named_type_ref("string")), ("id".to_owned(), named_type_ref("int"))].into_iter())]),
+        anonymous_type([fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), None)), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), None))].into_iter())]),
     ),
     case::field_names_constraint(
         load_anonymous_type_v2_0(r#" // For a schema with field_names constraint as below:

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -20,7 +20,7 @@
 //! ```
 
 use crate::authority::DocumentAuthority;
-use crate::isl::isl_constraint::{IslConstraint, IslConstraintImpl};
+use crate::isl::isl_constraint::IslConstraint;
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::{IslType, IslTypeImpl};
 use crate::isl::{IslSchema, IslVersion};
@@ -800,11 +800,7 @@ impl Resolver {
                 }
 
                 // top level named type definition can not contain `occurs` field as per ISL specification
-                if isl_type
-                    .constraints()
-                    .iter()
-                    .any(|c| matches!(c, IslConstraintImpl::Occurs(_)))
-                {
+                if value.as_struct().unwrap().get("occurs").is_some() {
                     return invalid_schema_error(
                         "Top level types must not contain `occurs` field in their definition",
                     );

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -607,6 +607,7 @@ mod type_definition_tests {
     use crate::isl::isl_constraint::v_1_0::*;
     use crate::isl::isl_range::Number;
     use crate::isl::isl_range::NumberRange;
+    use crate::isl::isl_range::Range;
     use crate::isl::isl_type::v_1_0::*;
     use crate::isl::isl_type::IslType;
     use crate::isl::isl_type_reference::v_1_0::*;
@@ -695,14 +696,14 @@ mod type_definition_tests {
         /* For a schema with ordered_elements constraint as below:
             { ordered_elements: [ symbol, { type: int }, ] }
         */
-        anonymous_type([ordered_elements([variably_occurring_type_ref(named_type_ref("symbol"), None), variably_occurring_type_ref(anonymous_type_ref([type_constraint(named_type_ref("int"))]), None)])]),
+        anonymous_type([ordered_elements([variably_occurring_type_ref(named_type_ref("symbol"), Range::required()), variably_occurring_type_ref(anonymous_type_ref([type_constraint(named_type_ref("int"))]), Range::required())])]),
     TypeDefinitionKind::anonymous([Constraint::ordered_elements([5, 36]), Constraint::type_constraint(34)])
     ),
     case::fields_constraint(
         /* For a schema with fields constraint as below:
             { fields: { name: string, id: int} }
         */
-        anonymous_type([fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), None)), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), None))].into_iter())]),
+        anonymous_type([fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), Range::optional())), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), Range::optional()))].into_iter())]),
     TypeDefinitionKind::anonymous([Constraint::fields(vec![("name".to_owned(), 4), ("id".to_owned(), 0)].into_iter()), Constraint::type_constraint(34)])
     ),
     case::field_names_constraint(

--- a/ion-schema/src/types.rs
+++ b/ion-schema/src/types.rs
@@ -695,14 +695,14 @@ mod type_definition_tests {
         /* For a schema with ordered_elements constraint as below:
             { ordered_elements: [ symbol, { type: int }, ] }
         */
-        anonymous_type([ordered_elements([named_type_ref("symbol"), anonymous_type_ref([type_constraint(named_type_ref("int"))])])]),
+        anonymous_type([ordered_elements([variably_occurring_type_ref(named_type_ref("symbol"), None), variably_occurring_type_ref(anonymous_type_ref([type_constraint(named_type_ref("int"))]), None)])]),
     TypeDefinitionKind::anonymous([Constraint::ordered_elements([5, 36]), Constraint::type_constraint(34)])
     ),
     case::fields_constraint(
         /* For a schema with fields constraint as below:
             { fields: { name: string, id: int} }
         */
-        anonymous_type([fields(vec![("name".to_owned(), named_type_ref("string")), ("id".to_owned(), named_type_ref("int"))].into_iter())]),
+        anonymous_type([fields(vec![("name".to_owned(), variably_occurring_type_ref(named_type_ref("string"), None)), ("id".to_owned(), variably_occurring_type_ref(named_type_ref("int"), None))].into_iter())]),
     TypeDefinitionKind::anonymous([Constraint::fields(vec![("name".to_owned(), 4), ("id".to_owned(), 0)].into_iter()), Constraint::type_constraint(34)])
     ),
     case::field_names_constraint(


### PR DESCRIPTION
### Issue #157:

### Description of changes:
This PR works on adding a variably occurring type reference implementation which will be used by the schema model.

### Grammar:
```ANTLR
<VARIABLY_OCCURRING_TYPE_ARGUMENT> ::= { <OCCURS>, <CONSTRAINT>... }
                                     | <TYPE_ARGUMENT>

<OCCURS> ::= occurs: <INT>
           | occurs: <RANGE_INT>
           | occurs: optional
           | occurs: required
```

### Ion Schema Specification:
https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#variably-occurring-type-arguments

### List of changes:
* adds implementation of `IslVariablyOccurringTypeRef` in isl module.
* adds changes for converting `IslVariablyOccurringTypeRef` to `VariablyOccurringTypeRef` which contains resolved `TypeId`.
* Construction of `ordered_elements` and `fields` constraints takes in `IslVariablyOccurringTypeRef` instead of previous `IslTypeRef`.
* modifies unit tests for variably occurring type references.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
