### PR TITLE
adds fixes for ISL 2.0 open content

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,15 +16,31 @@ jobs:
       checks: write
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
             submodules: recursive
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: stable
+            components: rustfmt, clippy
+            override: true
       - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
+        uses: actions-rs/cargo@v1
+        with:
+            command: build
+            args: --verbose
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+            command: test
+            args: --verbose
       - name: Rustfmt
-        run: cargo fmt --verbose -- --check
+        uses: actions-rs/cargo@v1
+        with:
+            command: fmt
+            args: --verbose -- --check
       # `clippy-check` will run `cargo clippy` on new pull requests. Due to a limitation in GitHub
       # permissions, the behavior of the Action is different depending on the source of the PR. If the
       # PR comes from the ion-schema-rust project itself, any suggestions will be added to the PR as comments.

--- a/ion-schema-tests-runner/src/generator.rs
+++ b/ion-schema-tests-runner/src/generator.rs
@@ -299,7 +299,7 @@ fn generate_preamble(root_dir_path: &Path) -> TokenStream {
             } else {
                 match schema {
                     Ok(_) => Err("Expected schema to be invalid".to_string()),
-                    Err(e) => Err(format!("{:?}", e)),
+                    Err(e) => Ok(()),
                 }
             }
         }

--- a/ion-schema-tests-runner/tests/ion-schema-tests-1-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-1-0.rs
@@ -11,6 +11,8 @@ ion_schema_tests!(
         "constraints::occurs::invalid::occurs_range_must_be_a_valid__satisfiable_range__1_",
         "constraints::scale::invalid::scale_must_be_an_integer_or_range__04_",
         "constraints::valid_values::all_types::value_should_be_invalid_for_type_valid_values_all_types__04_",
+        "nullable::*",
+        "schema::import::cycles::*",
         "schema::import::diamond_import::should_be_a_valid_schema",
         "schema::import::diamond_import::value_should_be_valid_for_type_diamond_import",
         "schema::import::import::value_should_be_(valid|invalid)_for_type",

--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -6,6 +6,7 @@ ion_schema_tests!(
     ignored(
         "imports",
         "schema::*",
+        "null_or::*",
         "constraints::contains",
         "constraints::ordered_elements",
         "constraints::precision",

--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -4,7 +4,6 @@ ion_schema_tests!(
     root = "ion-schema-tests/ion_schema_2_0/",
     // Support for ISL 2.0 is not completely implemented yet, so some tests are ignored.
     ignored(
-        "open_content",
         "imports",
         "schema::*",
         "constraints::contains",

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -131,6 +131,7 @@ impl IslSchema {
         IslSchema {
             schema: IslSchemaImpl::new(
                 id.as_ref(),
+                IslVersion::V1_0,
                 None,
                 imports,
                 types,
@@ -152,6 +153,7 @@ impl IslSchema {
         IslSchema {
             schema: IslSchemaImpl::new(
                 id.as_ref(),
+                IslVersion::V2_0,
                 Some(user_reserved_fields),
                 imports,
                 types,
@@ -163,6 +165,10 @@ impl IslSchema {
 
     pub fn id(&self) -> String {
         self.schema.id.to_owned()
+    }
+
+    pub fn version(&self) -> IslVersion {
+        self.schema.version
     }
 
     pub fn imports(&self) -> &[IslImport] {
@@ -194,6 +200,8 @@ impl IslSchema {
 pub(crate) struct IslSchemaImpl {
     /// Represents an id for the given ISL model
     id: String,
+    /// Represents the ISL version for given schema
+    version: IslVersion,
     /// Represents the user defined reserved fields
     /// For ISL 2.0 this contains the use reserved fields that are defined within schema header,
     /// Otherwise, it is None.
@@ -226,6 +234,7 @@ pub(crate) struct IslSchemaImpl {
 impl IslSchemaImpl {
     pub fn new<A: AsRef<str>>(
         id: A,
+        version: IslVersion,
         user_reserved_fields: Option<UserReservedFields>,
         imports: Vec<IslImport>,
         types: Vec<IslType>,
@@ -234,6 +243,7 @@ impl IslSchemaImpl {
     ) -> Self {
         Self {
             id: id.as_ref().to_owned(),
+            version,
             user_reserved_fields,
             imports,
             types,

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -45,7 +45,7 @@ pub mod external {
 }
 
 static ISL_VERSION_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
-static RESERVED_KEYWORD_ISL_VERSION_MARKER: OnceLock<Regex> = OnceLock::new();
+static RESERVED_WORD_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Checks if a value is an ISL version marker.
 fn is_isl_version_marker(text: &str) -> bool {
@@ -55,8 +55,8 @@ fn is_isl_version_marker(text: &str) -> bool {
 }
 
 /// Checks is a value is reserved keyword ISL version maker.
-fn is_reserved_keyword_isl_version_marker(text: &str) -> bool {
-    RESERVED_KEYWORD_ISL_VERSION_MARKER
+fn is_reserved_word(text: &str) -> bool {
+    RESERVED_WORD_REGEX
         .get_or_init(|| Regex::new(r"^(\$ion_schema(_.*)?|[a-z][a-z0-9]*(_[a-z0-9]+)*)$").unwrap())
         .is_match(text)
 }
@@ -273,10 +273,10 @@ impl UserReservedFields {
             return invalid_schema_error("User reserved fields mut be unannotated");
         }
 
-        if user_reserved_fields.iter().any(|f| {
-            is_reserved_keyword_isl_version_marker(f)
-                || ISL_2_0_KEYWORDS.binary_search(&f.as_str()).is_ok()
-        }) {
+        if user_reserved_fields
+            .iter()
+            .any(|f| is_reserved_word(f) || ISL_2_0_KEYWORDS.binary_search(&f.as_str()).is_ok())
+        {
             return invalid_schema_error(
                 "ISl 2.0 keywords may not be declared as user reserved fields",
             );

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -274,7 +274,8 @@ impl UserReservedFields {
         }
 
         if user_reserved_fields.iter().any(|f| {
-            is_reserved_keyword_isl_version_marker(f) || ISL_2_0_KEYWORDS.contains(&f.as_str())
+            is_reserved_keyword_isl_version_marker(f)
+                || ISL_2_0_KEYWORDS.binary_search(&f.as_str()).is_ok()
         }) {
             return invalid_schema_error(
                 "ISl 2.0 keywords may not be declared as user reserved fields",

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -113,7 +113,6 @@ impl Iterator for SchemaTypeIterator {
 mod schema_tests {
     use super::*;
     use crate::authority::MapDocumentAuthority;
-    use crate::isl::IslVersion;
     use crate::system::{Resolver, SchemaSystem};
     use ion_rs::element::Element;
     use rstest::*;
@@ -310,7 +309,7 @@ mod schema_tests {
     case::ieee754_float_constraint(
         load(r#" // For a schema with ieee754_float constraint as below:
                         $ion_schema_2_0
-                        type:: { name: ieee754_float_type, iee4754_float: binary16 }
+                        type:: { name: ieee754_float_type, ieee754_float: binary16 }
                      "#).into_iter(),
         1 // this includes named type ieee754_float_type
     ),
@@ -324,13 +323,12 @@ mod schema_tests {
         let mut resolver = Resolver::new(vec![]);
 
         // create a isl from owned_elements and verifies if the result is `ok`
-        let isl =
-            resolver.isl_schema_from_elements(IslVersion::V1_0, owned_elements, "my_schema.isl");
-        assert!(isl.is_ok());
+        let isl_result = resolver.isl_schema_from_elements(owned_elements, "my_schema.isl");
+        assert!(isl_result.is_ok());
 
+        let isl = isl_result.unwrap();
         // create a schema from isl and verifies if the result is `ok`
-        let schema =
-            resolver.schema_from_isl_schema(IslVersion::V1_0, isl.unwrap(), type_store, None);
+        let schema = resolver.schema_from_isl_schema(isl.version(), isl, type_store, None);
         assert!(schema.is_ok());
 
         // check if the types of the created schema matches with the actual types specified by test case

--- a/ion-schema/src/schema.rs
+++ b/ion-schema/src/schema.rs
@@ -326,7 +326,7 @@ mod schema_tests {
         let isl_result = resolver.isl_schema_from_elements(owned_elements, "my_schema.isl");
         assert!(isl_result.is_ok());
 
-        let isl = isl_result.unwrap();
+        let isl = isl_result.expect("ISL schema should be syntactically correct");
         // create a schema from isl and verifies if the result is `ok`
         let schema = resolver.schema_from_isl_schema(isl.version(), isl, type_store, None);
         assert!(schema.is_ok());

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -30,7 +30,7 @@ use crate::result::{
 };
 use crate::schema::Schema;
 use crate::types::{BuiltInTypeDefinition, Nullability, TypeDefinitionImpl, TypeDefinitionKind};
-use crate::{is_isl_version_marker, UserReservedFields};
+use crate::{is_isl_version_marker, is_reserved_keyword_isl_version_marker, UserReservedFields};
 use ion_rs::element::{Annotations, Element};
 use ion_rs::types::IonType::Struct;
 use ion_rs::IonType;
@@ -754,8 +754,6 @@ impl Resolver {
         let mut open_content = vec![];
         let mut isl_user_reserved_fields = UserReservedFields::default();
         let mut isl_version = IslVersion::V1_0;
-        let reserved_keyword_version_marker =
-            Regex::new(r"^(\$ion_schema(_.*)?|[a-z][a-z0-9]*(_[a-z0-9]+)*)$").unwrap();
 
         let mut found_header = false;
         let mut found_footer = false;
@@ -875,7 +873,7 @@ impl Resolver {
                     && value
                         .annotations()
                         .iter()
-                        .any(|a| reserved_keyword_version_marker.is_match(a.text().unwrap()))
+                        .any(|a| is_reserved_keyword_isl_version_marker(a.text().unwrap()))
                 {
                     return invalid_schema_error(
                         "top level open content may not be annotated with any reserved keyword",

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -30,7 +30,7 @@ use crate::result::{
 };
 use crate::schema::Schema;
 use crate::types::{BuiltInTypeDefinition, Nullability, TypeDefinitionImpl, TypeDefinitionKind};
-use crate::{is_isl_version_marker, is_reserved_keyword_isl_version_marker, UserReservedFields};
+use crate::{is_isl_version_marker, is_reserved_word, UserReservedFields};
 use ion_rs::element::{Annotations, Element};
 use ion_rs::types::IonType::Struct;
 use ion_rs::IonType;
@@ -874,7 +874,7 @@ impl Resolver {
                     && value
                         .annotations()
                         .iter()
-                        .any(|a| is_reserved_keyword_isl_version_marker(a.text().unwrap()))
+                        .any(|a| is_reserved_word(a.text().unwrap()))
                 {
                     return invalid_schema_error(
                         "top level open content may not be annotated with any reserved keyword",

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -862,6 +862,7 @@ impl Resolver {
                 // open content
                 if isl_version == IslVersion::V2_0
                     && value.ion_type() == IonType::Symbol
+                    && !value.is_null()
                     && is_isl_version_marker(value.as_text().unwrap())
                 {
                     return invalid_schema_error(


### PR DESCRIPTION
### Description of changes:
This PR works on adding fixes for ISL 2.0 open content.

### List of changes:
* adds version information in the `IslSchema` model
* modifies generator for invalid schema tests to return `Ok` on violation
* modifies user reserved fields to not include reserved keywords and ISL 2.0 keywords
* modifies `isl_schema_from_elements` to consider the position of version marker for ISL 2.0

### Test:
adds tests from `ion-schema-tests` for ISL 2.0 open content

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
