### PR TITLE
adds `new_schema()` for `SchemaSystem` and minor ISL model fixes

### DIFF
--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -184,6 +184,7 @@ impl Constraint {
                         &a,
                         annotations_modifiers.contains(&"required"),
                     ),
+                    IslVersion::V1_0,
                 )
             })
             .collect();

--- a/ion-schema/src/isl/isl_constraint.rs
+++ b/ion-schema/src/isl/isl_constraint.rs
@@ -195,6 +195,7 @@ pub mod v_1_0 {
                         &a,
                         annotations_modifiers.contains(&"required"),
                     ),
+                    IslVersion::V1_0,
                 )
             })
             .collect();
@@ -444,6 +445,7 @@ pub mod v_2_0 {
                 Annotation::new(
                     a.as_text().unwrap().to_owned(),
                     Annotation::is_annotation_required(&a, is_required),
+                    IslVersion::V2_0,
                 )
             })
             .collect();
@@ -1132,6 +1134,7 @@ impl IslSimpleAnnotationsConstraint {
                                 e,
                                 annotation_modifiers.contains(&"required"),
                             ),
+                            isl_version,
                         )
                     })
                     .ok_or(invalid_schema_error_raw(

--- a/ion-schema/src/isl/isl_type_reference.rs
+++ b/ion-schema/src/isl/isl_type_reference.rs
@@ -233,8 +233,12 @@ impl IslTypeRefImpl {
                         return invalid_schema_error("an inline import type reference does not have `type` field specified")
                     }
                     IslImport::Type(isl_import_type) => { isl_import_type }
-                    IslImport::TypeAlias(_) => {
+                    IslImport::TypeAlias(_) if isl_version == IslVersion::V2_0 => {
                         return invalid_schema_error("an inline import type reference can not have `alias` field specified")
+                    }
+                    IslImport::TypeAlias(isl_import_type) => {
+                        // consider the type alias as open content for ISL 1.0
+                        IslImportType::new(isl_import_type.id().to_owned(), isl_import_type.type_name().to_owned(), None)
                     }
                 };
                 // if an inline import type is encountered add it in the inline_imports_types

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -94,7 +94,7 @@ pub mod util;
 
 /// Represents Ion Schema Language Versions
 /// Currently it support v1.0 and v2.0
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum IslVersion {
     V1_0,
     V2_0,

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -18,13 +18,18 @@ use std::fmt::{Display, Formatter};
 /// `annotations`: `<https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#annotations>`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Annotation {
+    isl_version: IslVersion,
     value: String,
     is_required: bool, // Specifies whether an annotation's occurrence is required or optional
 }
 
 impl Annotation {
-    pub fn new(value: String, is_required: bool) -> Self {
-        Self { value, is_required }
+    pub fn new(value: String, is_required: bool, isl_version: IslVersion) -> Self {
+        Self {
+            value,
+            is_required,
+            isl_version,
+        }
     }
 
     pub fn value(&self) -> &String {

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -8,7 +8,7 @@ use crate::isl::isl_type::IslTypeImpl;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use crate::violation::{Violation, ViolationCode};
 use ion_rs::element::{Element, Struct};
-use ion_rs::Symbol;
+use ion_rs::{IonWriter, Symbol};
 use regex::Regex;
 use std::fmt::{Display, Formatter};
 use std::sync::OnceLock;
@@ -296,6 +296,7 @@ impl UserReservedFields {
                     .schema_header_fields
                     .contains(&f.text().unwrap().to_owned())
                     && f.text().unwrap() != "user_reserved_fields"
+                    && f.text().unwrap() != "imports"
             })
             .collect();
 

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -8,7 +8,7 @@ use crate::isl::isl_type::IslTypeImpl;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
 use crate::violation::{Violation, ViolationCode};
 use ion_rs::element::{Element, Struct};
-use ion_rs::{IonWriter, Symbol};
+use ion_rs::Symbol;
 use regex::Regex;
 use std::fmt::{Display, Formatter};
 use std::sync::OnceLock;

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -1144,11 +1144,32 @@ impl SchemaSystem {
             .load_schema(id, &mut TypeStore::default(), None)
     }
 
+    /// Constructs a new schema using provided ISL content.
+    pub fn new_schema(&mut self, schema_content: &[u8], id: &str) -> IonSchemaResult<Arc<Schema>> {
+        let elements = Element::read_all(schema_content)?;
+        let isl = self
+            .resolver
+            .isl_schema_from_elements(elements.into_iter(), id)?;
+        self.resolver
+            .schema_from_isl_schema(isl.version(), isl, &mut TypeStore::default(), None)
+    }
+
     /// Requests each of the provided [`DocumentAuthority`]s, in order, to get ISL model for the
     /// requested schema id until one successfully resolves it.
     /// If an authority throws an exception, resolution silently proceeds to the next authority.
     pub fn load_isl_schema<A: AsRef<str>>(&mut self, id: A) -> IonSchemaResult<IslSchema> {
         self.resolver.load_isl_schema(id, None)
+    }
+
+    /// Constructs a new ISL model using provided ISL content.
+    pub fn new_isl_schema(
+        &mut self,
+        schema_content: &[u8],
+        id: &str,
+    ) -> IonSchemaResult<IslSchema> {
+        let elements = Element::read_all(schema_content)?;
+        self.resolver
+            .isl_schema_from_elements(elements.into_iter(), id)
     }
 
     /// Resolves given ISL 1.0 model into a [Schema].
@@ -2165,6 +2186,90 @@ mod schema_system_tests {
 
         // verify the resolved schema generated from the ISL 2.0 model that contains ISL 1.0 constraints is invalid
         assert!(&schema.is_err());
+    }
+
+    #[test]
+    fn new_schema_test() {
+        let mut schema_system = SchemaSystem::new(vec![]);
+        let schema = schema_system.new_schema(
+            r#"
+                $ion_schema_2_0
+                schema_header::{}
+                
+                type::{
+                  name: my_type,
+                  type: string,
+                }
+                
+                schema_footer::{}
+            "#
+            .as_bytes(),
+            "sample.isl",
+        );
+        assert!(schema.is_ok());
+    }
+
+    #[test]
+    fn new_schema_invalid_test() {
+        let mut schema_system = SchemaSystem::new(vec![]);
+        let schema = schema_system.new_schema(
+            r#"
+                $ion_schema_2_0
+                schema_header::{}
+                
+                type::{
+                  name: my_type,
+                  type: nullable::string, // `nullable` annotation is not supported in ISL 2.0
+                }
+                
+                schema_footer::{}
+            "#
+            .as_bytes(),
+            "sample.isl",
+        );
+        assert!(schema.is_err());
+    }
+
+    #[test]
+    fn new_isl_schema_test() {
+        let mut schema_system = SchemaSystem::new(vec![]);
+        let isl = schema_system.new_isl_schema(
+            r#"
+                $ion_schema_2_0
+                schema_header::{}
+                
+                type::{
+                  name: my_type,
+                  type: string,
+                }
+                
+                schema_footer::{}
+            "#
+            .as_bytes(),
+            "sample.isl",
+        );
+        assert!(isl.is_ok());
+    }
+
+    #[test]
+    fn new_isl_schema_invalid_test() {
+        let mut schema_system = SchemaSystem::new(vec![]);
+        let isl = schema_system.new_isl_schema(
+            r#"
+                $ion_schema_2_0
+                schema_header::{}
+                
+                type::{
+                  name: my_type,
+                  type: nullable::string, // `nullable` annotation is not supported in ISL 2.0
+                }
+                
+                schema_footer::{}
+            "#
+            .as_bytes(),
+            "sample.isl",
+        );
+        assert!(isl.is_err());
     }
 
     #[test]

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -1513,6 +1513,7 @@ mod schema_system_tests {
             (
                 "sample_number.isl",
                 r#"
+                    $ion_schema_2_0
                     schema_header::{
                       imports: [],
                     }
@@ -1537,6 +1538,7 @@ mod schema_system_tests {
             (
                 "sample_decimal.isl",
                 r#"
+                    $ion_schema_2_0
                     schema_header::{
                       imports: [],
                     }

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -807,7 +807,7 @@ impl Resolver {
                         let user_reserved_fields_struct = user_reserved_fields_element
                             .as_struct()
                             .ok_or(invalid_schema_error_raw(
-                                "User reserved field must be non-null struct",
+                                "User reserved field must be a non-null struct",
                             ))?;
 
                         isl_user_reserved_fields =
@@ -2195,7 +2195,7 @@ mod schema_system_tests {
     fn new_schema_test() {
         let mut schema_system = SchemaSystem::new(vec![]);
         let schema = schema_system.new_schema(
-            r#"
+            br#"
                 $ion_schema_2_0
                 schema_header::{}
                 
@@ -2205,8 +2205,7 @@ mod schema_system_tests {
                 }
                 
                 schema_footer::{}
-            "#
-            .as_bytes(),
+            "#,
             "sample.isl",
         );
         assert!(schema.is_ok());
@@ -2216,7 +2215,7 @@ mod schema_system_tests {
     fn new_schema_invalid_test() {
         let mut schema_system = SchemaSystem::new(vec![]);
         let schema = schema_system.new_schema(
-            r#"
+            br#"
                 $ion_schema_2_0
                 schema_header::{}
                 
@@ -2226,8 +2225,7 @@ mod schema_system_tests {
                 }
                 
                 schema_footer::{}
-            "#
-            .as_bytes(),
+            "#,
             "sample.isl",
         );
         assert!(schema.is_err());
@@ -2237,7 +2235,7 @@ mod schema_system_tests {
     fn new_isl_schema_test() {
         let mut schema_system = SchemaSystem::new(vec![]);
         let isl = schema_system.new_isl_schema(
-            r#"
+            br#"
                 $ion_schema_2_0
                 schema_header::{}
                 
@@ -2247,8 +2245,7 @@ mod schema_system_tests {
                 }
                 
                 schema_footer::{}
-            "#
-            .as_bytes(),
+            "#,
             "sample.isl",
         );
         assert!(isl.is_ok());
@@ -2258,7 +2255,7 @@ mod schema_system_tests {
     fn new_isl_schema_invalid_test() {
         let mut schema_system = SchemaSystem::new(vec![]);
         let isl = schema_system.new_isl_schema(
-            r#"
+            br#"
                 $ion_schema_2_0
                 schema_header::{}
                 
@@ -2268,8 +2265,7 @@ mod schema_system_tests {
                 }
                 
                 schema_footer::{}
-            "#
-            .as_bytes(),
+            "#,
             "sample.isl",
         );
         assert!(isl.is_err());


### PR DESCRIPTION
### Description of changes:
This PR works on adding `new_schema` for `SchemaSystem` and adds minor ISL model related fixes.

### List of changes:
* adds new_schema and new_isl_schema in `SchemaSystem`
* adds fixes for user reserved fields
  * `user_reserved_fields` should not consider validation for `imports`.
  * Incorrect error "User reserved field must be non-null and unannotated struct" was thrown when `user_reserved_fields` didn't even exist. 
* adds version information for Annotation
  * this will be useful to determine whether annotation is allowed or not
for each annotation in the annotations list
* adds a fix for inline import
  * inline import should not accept `as` for ISL 2.0
  * inline import should consider `as` open content for ISL 1.0


### Test: 
adds tests for `new_schema()` and `new_isl_schema()` .

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
