### PR TITLE
Bumps the version to v0.8.0

### DIFF
--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-schema-schemas/isl/**",
     "*.pdf"
 ]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
### Description of changes:
This PR updates the `ion-schema` version to 0.8.0.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
