### PR TITLE
Updates `ion-rs` dependency to v0.18.1

### DIFF
--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.18.0"
+ion-rs = "0.18.1"
 ion-schema = { path = "../ion-schema" }
 quote = "1.0.21"
 syn = "1.0.102"

--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.17.0"
+ion-rs = "0.18.0"
 ion-schema = { path = "../ion-schema" }
 quote = "1.0.21"
 syn = "1.0.102"

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.18.0"
+ion-rs = "0.18.1"
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "0.17.0"
+ion-rs = "0.18.0"
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/ion-schema/src/constraint.rs
+++ b/ion-schema/src/constraint.rs
@@ -18,7 +18,7 @@ use crate::types::TypeValidator;
 use crate::violation::{Violation, ViolationCode};
 use crate::IonSchemaElement;
 use ion_rs::element::Element;
-use ion_rs::ion_eq::IonEq;
+use ion_rs::IonData;
 use ion_rs::{Int, IonType};
 use num_traits::ToPrimitive;
 use regex::{Regex, RegexBuilder};
@@ -2042,9 +2042,11 @@ impl ConstraintValidator for ValidValuesConstraint {
                         },
                         ValidValue::Element(element) => {
                             // get value without annotations
-                            let value = value.value();
+                            let value: IonData<_> = value.value().into();
+                            let actual_value: IonData<_> = element.value().into();
 
-                            if element.value().ion_eq(value) {
+                            // this comparison uses the Ion equivalence based on Ion specification
+                            if actual_value == value {
                                 return Ok(());
                             }
                         }

--- a/ion-schema/src/isl/isl_range.rs
+++ b/ion-schema/src/isl/isl_range.rs
@@ -9,7 +9,7 @@ use ion_rs::element::writer::ElementWriter;
 use ion_rs::element::Element;
 use ion_rs::external::bigdecimal::num_bigint::BigInt;
 use ion_rs::external::bigdecimal::{BigDecimal, One};
-use ion_rs::types::integer::IntAccess;
+use ion_rs::types::IntAccess;
 use ion_rs::{element, Decimal, Int, IonType, IonWriter, Timestamp};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};

--- a/ion-schema/src/isl/mod.rs
+++ b/ion-schema/src/isl/mod.rs
@@ -388,9 +388,9 @@ mod isl_tests {
     use crate::result::IonSchemaResult;
     use crate::system::SchemaSystem;
     use ion_rs::element::Element;
-    use ion_rs::types::decimal::*;
-    use ion_rs::types::integer::Int as IntegerValue;
-    use ion_rs::types::timestamp::Timestamp;
+    use ion_rs::types::Decimal;
+    use ion_rs::types::Int as IntegerValue;
+    use ion_rs::types::Timestamp;
     use ion_rs::Symbol;
     use ion_rs::{IonType, TextWriterBuilder};
     use rstest::*;

--- a/ion-schema/src/isl/util.rs
+++ b/ion-schema/src/isl/util.rs
@@ -3,7 +3,7 @@ use crate::isl::{IslVersion, WriteToIsl};
 use crate::result::{invalid_schema_error, IonSchemaError, IonSchemaResult};
 use ion_rs::element::writer::ElementWriter;
 use ion_rs::element::Element;
-use ion_rs::types::timestamp::Precision;
+use ion_rs::types::Precision;
 use ion_rs::{IonWriter, Symbol, Timestamp};
 use num_traits::abs;
 use std::cmp::Ordering;


### PR DESCRIPTION
### Description of changes:
This PR updates `ion-rs` dependency to v0.18.1.

### List of changes:
- changes the imports statements for some of the modules.
- Uses `IonData` which provides `ion_eq` or Ion data model equivalence based on [Ion specification](https://amazon-ion.github.io/ion-docs/docs/spec.html).

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
