### PR TITLE
Disable default features for chrono, avoid CVE

### DIFF
--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -26,7 +26,11 @@ ion-rs = "0.18.1"
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"
-chrono = "0.4"
+# chrono < 0.5 brings in a deprecated version of the `time` crate via `oldtime` feature by default
+# this makes it explicitly not do this as there is an advisory warning against this:
+# See: https://github.com/chronotope/chrono/issues/602 
+# and  https://github.com/chronotope/chrono/issues/1073
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
 regex = "1.5.6"
 half = "2.2.1"
 


### PR DESCRIPTION
By default the `oldtime` feature is enabled, which brings in the deprecated version of `time` dependency, which exposes dependency the risk of CVE-2020-26235.

This fix manually disables the `oldtime` feature of chrono.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
