### PR TITLE
Removes unused `chrono` dependency

### DIFF
--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -26,7 +26,6 @@ ion-rs = "0.18.1"
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"
-chrono = "0.4"
 regex = "1.5.6"
 half = "2.2.1"
 


### PR DESCRIPTION
### Description of changes:
This PR removes the unused `chrono` dependency. `chrono` was added as part of timestamp ranges implementation but with the latest changes the dependency is no longer being used. 

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
