### PR TITLE
fix(ion-schema): add non_exhaustive to ViolationCode enum

### DIFF
--- a/ion-schema/src/violation.rs
+++ b/ion-schema/src/violation.rs
@@ -95,6 +95,7 @@ impl fmt::Display for Violation {
 
 /// Represents violation code that indicates the type of the violation
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ViolationCode {
     AllTypesNotMatched,
     AnnotationMismatched,


### PR DESCRIPTION
### Issue #, if available:
https://github.com/amazon-ion/ion-schema-rust/issues/209

### Description of changes:

small tweak for `ViolationCode` to simplify new violation codes when they are added if/when new versions of ISL add new constraints.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
