### PR TITLE
Makes IonSchemaElement use borrowed Elements

### DIFF
--- a/ion-schema-tests-runner/Cargo.toml
+++ b/ion-schema-tests-runner/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = "1.0.0-rc.7"
+ion-rs = "1.0.0-rc.8"
 ion-schema = { path = "../ion-schema" }
 quote = "1.0.21"
 syn = "1.0.102"

--- a/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
+++ b/ion-schema-tests-runner/tests/ion-schema-tests-2-0.rs
@@ -2,11 +2,11 @@ use ion_schema_tests_runner::ion_schema_tests;
 
 ion_schema_tests!(
     root = "ion-schema-tests/ion_schema_2_0/",
-    // Support for ISL 2.0 is not completely implemented yet, so some tests are ignored.
     ignored(
+        // Not fully implemented yet.
         "imports",
         "constraints::ordered_elements",
-        "constraints::precision",
-        "constraints::regex::value_should_be_invalid_for_type_regex_unescaped_newline__2_", // https://github.com/amazon-ion/ion-rust/issues/399
+        // Failing because of https://github.com/amazon-ion/ion-rust/issues/399
+        "constraints::regex::value_should_be_invalid_for_type_regex_unescaped_newline__2_",
     )
 );

--- a/ion-schema/Cargo.toml
+++ b/ion-schema/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ion-rs = { version = "1.0.0-rc.7", features = ["experimental-reader-writer"] }
+ion-rs = { version = "1.0.0-rc.8", features = ["experimental-reader-writer"] }
 thiserror = "1.0"
 num-bigint = "0.3"
 num-traits = "0.2"

--- a/ion-schema/src/ion_schema_element.rs
+++ b/ion-schema/src/ion_schema_element.rs
@@ -1,0 +1,216 @@
+use crate::ion_path::IonPath;
+use crate::violation::{Violation, ViolationCode};
+use ion_rs::{Element, IonType, Struct};
+use std::fmt::{Display, Formatter};
+
+/// Extends [IonType] by adding a "Document" variant for Ion Schema.
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub(crate) enum IonSchemaElementType {
+    Null,
+    Bool,
+    Int,
+    Float,
+    Decimal,
+    Timestamp,
+    Symbol,
+    String,
+    Clob,
+    Blob,
+    List,
+    SExp,
+    Struct,
+    Document,
+}
+
+impl Display for IonSchemaElementType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let text = match self {
+            IonSchemaElementType::Null => "null",
+            IonSchemaElementType::Bool => "bool",
+            IonSchemaElementType::Int => "int",
+            IonSchemaElementType::Float => "float",
+            IonSchemaElementType::Decimal => "decimal",
+            IonSchemaElementType::Timestamp => "timestamp",
+            IonSchemaElementType::Symbol => "symbol",
+            IonSchemaElementType::String => "string",
+            IonSchemaElementType::Clob => "clob",
+            IonSchemaElementType::Blob => "blob",
+            IonSchemaElementType::List => "list",
+            IonSchemaElementType::SExp => "sexp",
+            IonSchemaElementType::Struct => "struct",
+            IonSchemaElementType::Document => "document",
+        };
+        f.write_str(text)
+    }
+}
+
+impl From<IonType> for IonSchemaElementType {
+    fn from(value: IonType) -> Self {
+        match value {
+            IonType::Null => IonSchemaElementType::Null,
+            IonType::Bool => IonSchemaElementType::Bool,
+            IonType::Int => IonSchemaElementType::Int,
+            IonType::Float => IonSchemaElementType::Float,
+            IonType::Decimal => IonSchemaElementType::Decimal,
+            IonType::Timestamp => IonSchemaElementType::Timestamp,
+            IonType::Symbol => IonSchemaElementType::Symbol,
+            IonType::String => IonSchemaElementType::String,
+            IonType::Clob => IonSchemaElementType::Clob,
+            IonType::Blob => IonSchemaElementType::Blob,
+            IonType::List => IonSchemaElementType::List,
+            IonType::SExp => IonSchemaElementType::SExp,
+            IonType::Struct => IonSchemaElementType::Struct,
+        }
+    }
+}
+
+/// Internal-only backing representation for [IonSchemaElement].
+#[derive(Debug, Clone, PartialEq)]
+enum IonSchemaElementKind<'a> {
+    SingleElement(&'a Element),
+    Document(&'a [Element]),
+}
+
+/// Represents a value that can be validated by Ion Schema.
+///
+/// An [IonSchemaElement] can be constructed from [Element] to represent a single Ion value, or
+/// from [Document] to represent the Ion Schema document type.
+///
+/// In general, users do not need to construct this directly. Ion Schema APIs accept
+/// `Into<IonSchemaElement>` rather than directly accepting `IonSchemaElement`.
+///
+/// See [TypeDefinition::validate] for examples of use.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IonSchemaElement<'a> {
+    content: IonSchemaElementKind<'a>,
+}
+
+impl<'a> IonSchemaElement<'a>
+where
+    Self: 'a,
+{
+    pub(crate) fn as_sequence_iter(&'a self) -> Option<impl Iterator<Item = &'a Element>> {
+        match &self.content {
+            IonSchemaElementKind::SingleElement(e) => e
+                .as_sequence()
+                .map(|s| AsRef::<[Element]>::as_ref(s).iter()),
+            IonSchemaElementKind::Document(d) => Some(d.iter()),
+        }
+    }
+
+    pub(crate) fn as_struct(&'a self) -> Option<&'a Struct> {
+        match self.content {
+            IonSchemaElementKind::SingleElement(e) => e.as_struct(),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_element(&'a self) -> Option<&'a Element> {
+        match self.content {
+            IonSchemaElementKind::SingleElement(element) => Some(element),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_document(&'a self) -> Option<impl Iterator<Item = &'a Element>> {
+        match &self.content {
+            IonSchemaElementKind::Document(d) => Some(d.iter()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn ion_schema_type(&self) -> IonSchemaElementType {
+        match self.as_element() {
+            Some(e) => e.ion_type().into(),
+            _ => IonSchemaElementType::Document,
+        }
+    }
+
+    pub(crate) fn is_null(&self) -> bool {
+        match self.as_element() {
+            Some(e) => e.is_null(),
+            _ => false,
+        }
+    }
+
+    pub(crate) fn expect_element_of_type(
+        &self,
+        types: &[IonType],
+        constraint_name: &str,
+        ion_path: &mut IonPath,
+    ) -> Result<&Element, Violation> {
+        match self.as_element() {
+            Some(element) => {
+                if !types.contains(&element.ion_type()) || element.is_null() {
+                    // If it's an Element but the type isn't one of `types`,
+                    // return a Violation with the constraint name.
+                    return Err(Violation::new(
+                        constraint_name,
+                        ViolationCode::TypeMismatched,
+                        format!("expected {:?} but found {}", types, element.ion_type()),
+                        ion_path,
+                    ));
+                }
+                // If it's an Element of an expected type, return a ref to it.
+                Ok(element)
+            }
+            None => {
+                // If it's a Document, return a Violation with the constraint name
+                Err(Violation::new(
+                    constraint_name,
+                    ViolationCode::TypeMismatched,
+                    format!("expected {types:?} but found document"),
+                    ion_path,
+                ))
+            }
+        }
+    }
+}
+
+impl<'a> Display for IonSchemaElement<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match &self.content {
+            IonSchemaElementKind::SingleElement(element) => {
+                write!(f, "{element}")
+            }
+            IonSchemaElementKind::Document(document) => {
+                write!(f, "/* Ion document */ ")?;
+                for value in document.iter() {
+                    write!(f, "{value} ")?;
+                }
+                write!(f, "/* end */")
+            }
+        }
+    }
+}
+
+impl<'a> From<&'a Element> for IonSchemaElement<'a> {
+    fn from(value: &'a Element) -> Self {
+        IonSchemaElement {
+            content: IonSchemaElementKind::SingleElement(value),
+        }
+    }
+}
+
+/// Marker type to indicate that a sequence of [Element] should be validated as a `document`.
+pub struct DocumentHint<'a>(&'a [Element]);
+
+pub trait AsDocumentHint<'a> {
+    fn as_document(&'a self) -> DocumentHint<'a>;
+}
+
+impl<'a, T> AsDocumentHint<'a> for T
+where
+    T: AsRef<[Element]> + 'a,
+{
+    fn as_document(&'a self) -> DocumentHint<'a> {
+        DocumentHint(self.as_ref())
+    }
+}
+
+impl<'a> From<DocumentHint<'a>> for IonSchemaElement<'a> {
+    fn from(value: DocumentHint<'a>) -> Self {
+        let content: IonSchemaElementKind = IonSchemaElementKind::Document(value.0);
+        IonSchemaElement { content }
+    }
+}

--- a/ion-schema/src/lib.rs
+++ b/ion-schema/src/lib.rs
@@ -4,9 +4,7 @@
 use crate::isl::isl_constraint::IslConstraintValue;
 use crate::isl::isl_type::IslType;
 use crate::result::{invalid_schema_error, invalid_schema_error_raw, IonSchemaResult};
-use ion_rs::{
-    Element, IonResult, Struct, StructWriter, Symbol, ValueWriter, WriteAsIon,
-};
+use ion_rs::{Element, IonResult, Struct, StructWriter, Symbol, ValueWriter, WriteAsIon};
 use regex::Regex;
 use std::sync::OnceLock;
 

--- a/ion-schema/src/nfa.rs
+++ b/ion-schema/src/nfa.rs
@@ -6,7 +6,6 @@ use crate::IonSchemaElement;
 use ion_rs::Element;
 use std::collections::{HashMap, HashSet};
 use std::iter::Peekable;
-use std::slice::Iter;
 use std::sync::Arc;
 
 /// Represents an id for a state in NFA
@@ -156,8 +155,11 @@ impl NfaEvaluation {
     }
 
     /// Validates provided ordered elements against referenced [Nfa]
-    pub fn validate_ordered_elements(&mut self, elements: &[Element], type_store: &TypeStore) {
-        let mut elements_iter = elements.iter().peekable();
+    pub fn validate_ordered_elements<'a, T: Iterator<Item = &'a Element>>(
+        &mut self,
+        mut elements_iter: Peekable<T>,
+        type_store: &TypeStore,
+    ) {
         // given elements are actually events for the `Nfa` referenced in this `NfaEvaluation`.
         // iterate through all elements and update state-visit count(`NfaRun`) for all possible transitions for given element(event).
         while let Some(element) = elements_iter.next() {
@@ -180,12 +182,12 @@ impl NfaEvaluation {
 
     /// Evaluates given transitions using referenced [Nfa]
     /// For each evaluation of a transition it adds next possible states into `next_states`
-    fn evaluate_transitions(
+    fn evaluate_transitions<'a, T: Iterator<Item = &'a Element>>(
         &self,
         nfa_run: &NfaRun,
         transitions: HashSet<Transition>,
         current_element: &Element,
-        elements: &mut Peekable<Iter<Element>>,
+        elements: &mut Peekable<T>,
         type_store: &TypeStore,
         nfa_runs: &mut HashSet<NfaRun>,
     ) {
@@ -233,12 +235,12 @@ impl NfaEvaluation {
 
     // This is a helper method that is used by `evaluate_transitions()` to resolve destination states that are optional
     // for optional destination states, add transitions to next states skipping the optional state
-    fn evaluate_transition_to_optional_state(
+    fn evaluate_transition_to_optional_state<'a, T: Iterator<Item = &'a Element>>(
         &self,
         visits: usize,
         transition: &Transition,
         element: &Element,
-        elements: &mut Peekable<Iter<Element>>,
+        elements: &mut Peekable<T>,
         type_store: &TypeStore,
         next_states: &mut HashSet<NfaRun>,
     ) {
@@ -267,12 +269,12 @@ impl NfaEvaluation {
     // this method iterates through elements to satisfy minimum required occurrences for given transition
     // It will return false if an invalid Ion value is found which doesn't satisfy minimum occurrence requirement for given transition
     // Otherwise it will return true
-    fn evaluate_transition_to_self(
+    fn evaluate_transition_to_self<'a, T: Iterator<Item = &'a Element>>(
         &self,
         visits: usize,
         transition: &Transition,
         element: &Element,
-        elements: &mut Peekable<Iter<Element>>,
+        elements: &mut Peekable<T>,
         type_store: &TypeStore,
         next_states: &mut HashSet<NfaRun>,
     ) -> bool {

--- a/ion-schema/src/system.rs
+++ b/ion-schema/src/system.rs
@@ -20,6 +20,7 @@
 //! ```
 
 use crate::authority::DocumentAuthority;
+use crate::ion_schema_element::IonSchemaElementType;
 use crate::isl::isl_import::{IslImport, IslImportType};
 use crate::isl::isl_type::IslType;
 use crate::isl::{IslSchema, IslVersion};
@@ -437,16 +438,13 @@ impl PendingTypes {
 
 /// Represents an array of BuiltIn derived ISL types
 /// for more information: https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#type-system
-static DERIVED_ISL_TYPES: [&str; 10] = [
+static DERIVED_ISL_TYPES: [&str; 9] = [
     "type::{ name: lob, one_of: [ blob, clob ] }",
     "type::{ name: number, one_of: [ decimal, float, int ] }",
     "type::{ name: text, one_of: [ string, symbol ] }",
     "type::{ name: $lob, one_of: [ $blob, $clob ] }",
     "type::{ name: $number, one_of: [ $decimal, $float, $int ] }",
     "type::{ name: $text, one_of: [ $string, $symbol ] }",
-    // this is just a place holder for document type,
-    // IonSchemaElement::Document(_) type is used to verify the correctness on the validation side
-    "type::{ name: document }",
     "type::{ name: $any, one_of: [ $blob, $bool, $clob, $decimal,
                                     $float, $int, $string, $symbol, $timestamp,
                                     $list, $sexp, $struct, $null, document ] }",
@@ -490,8 +488,8 @@ impl TypeStore {
         let isl_version = IslVersion::V1_0;
         // add all ion types to the type store
         // TODO: this array can be turned into an iterator implementation in ion-rust for IonType
-        use IonType::*;
-        let built_in_atomic_types: [IonType; 12] = [
+        use IonSchemaElementType::*;
+        let built_in_atomic_types: [IonSchemaElementType; 12] = [
             Int, Float, Decimal, Timestamp, String, Symbol, Bool, Blob, Clob, SExp, List, Struct,
         ];
         // add all the atomic ion types that doesn't allow nulls [type_ids: 0 - 11]
@@ -512,6 +510,12 @@ impl TypeStore {
 
         // add $null to the built-in types [type_id: 24]
         self.add_builtin_type(&BuiltInTypeDefinition::Atomic(Null, Nullability::Nullable));
+
+        // add document type
+        self.add_builtin_type(&BuiltInTypeDefinition::Atomic(
+            Document,
+            Nullability::NotNullable,
+        ));
 
         // get the derived built in types map and related text value for given type_name [type_ids: 25 - 33]
         let pending_types = &mut PendingTypes::default();

--- a/ion-schema/src/type_reference.rs
+++ b/ion-schema/src/type_reference.rs
@@ -4,7 +4,7 @@ use crate::isl::ranges::UsizeRange;
 use crate::result::ValidationResult;
 use crate::system::{TypeId, TypeStore};
 use crate::types::TypeValidator;
-use crate::IonSchemaElement;
+use crate::{IonSchemaElement, IonSchemaElementType};
 use ion_rs::IonType;
 
 /// Provides reference to a type definition.
@@ -60,10 +60,8 @@ impl TypeValidator for TypeReference {
                 }
             }
             NullOr => {
-                if let IonSchemaElement::SingleElement(element) = value {
-                    if element.ion_type() == IonType::Null {
-                        return Ok(());
-                    }
+                if value.ion_schema_type() == IonSchemaElementType::Null {
+                    return Ok(());
                 }
             }
             Nothing => {}

--- a/wasm-schema-sandbox/Cargo.toml
+++ b/wasm-schema-sandbox/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 js-sys = "0.3.61"
 ion-schema = { path="../ion-schema" }
+ion-rs = "1.0.0-rc.8"
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
### Issue #, if available:

Fixes #214 
Fixes #137

### Description of changes:

Changes `IonSchemaElement` so that it holds references to `Element`s rather than owning `Element`s. Details in PR tour 🗺️  comments.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
